### PR TITLE
Make RT "worker friendly"

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,8 +237,7 @@ official term ECMAScript, since the term JavaScript is more widely known. [[ECMA
 
 <p>
     The <a href="#performanceresourcetiming">PerformanceResourceTiming</a>
-    interface facilitates timing measurement of downloadable resources on the
-    root page. For example, this interface is available for
+    interface facilitates timing measurement of downloadable resources. For example, this interface is available for
     <a href="http://www.w3.org/TR/XMLHttpRequest/#interface-xmlhttprequest">XMLHttpRequest</a> objects [[XMLHttpRequest]], HTML
     elements [[HTML5]] such as
     <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a>,
@@ -253,15 +252,13 @@ official term ECMAScript, since the term JavaScript is more widely known. [[ECMA
     as <a href="http://www.w3.org/TR/SVG11/struct.html#SVGElement">svg</a>.
 </p>
 
-<p>The term "resource" is also used to refer to these elements in this work. </p>
+<p>The term "resource" is used to refer to these elements and any other user-initiated fetches throughout this specification.</p>
 </section>
 
 <section id="resources-included">
 <h3>Resources Included in the <code><a href="#performanceresourcetiming">PerformanceResourceTiming</a></code> Interface</h3>
 <p>
-	All resources <a title='fetch' href="http://www.w3.org/TR/html5/infrastructure.html#fetch">fetched</a> by the current <a href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a> [[!HTML5]]
-	MUST be included as <a href="#performanceresourcetiming">PerformanceResourceTiming</a> objects in the <a href="http://www.w3.org/TR/performance-timeline/#sec-performance-timeline">Performance Timeline</a> of the
-	current <a href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>. Resources that are
+	All resources <a title='fetch' href="http://www.w3.org/TR/html5/infrastructure.html#fetch">fetched</a> by the current <a href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing</a> [[!HTML5]] or worker [[!WORKERS]] context's MUST be included as <a href="#performanceresourcetiming">PerformanceResourceTiming</a> objects in the <a href="http://www.w3.org/TR/performance-timeline/#sec-performance-timeline">Performance Timeline</a> of the relevant context. Resources that are
     retrieved from <a href="http://www.w3.org/TR/html5/browsers.html#relevant-application-cache" title='relevant application cache'>relevant
 application caches</a> or local resources MUST be included
     as <a href="#performanceresourcetiming">PerformanceResourceTiming</a> objects in the <a href="http://www.w3.org/TR/performance-timeline/#sec-performance-timeline">Performance Timeline</a> [[!performance-timeline]].
@@ -679,8 +676,7 @@ If such extensions are needed, e.g., for experimental purposes, vendors MUST use
 <p><img style="width:85%" src="resource-timing-overview-1.png" alt='Resource Timing attributes'></p>
 
 <ol>
-  <li>Once the <a href="http://www.w3.org/TR/html5/browsers.html#create-a-document-object">Window object of
-  the current document is created</a>, the user agent MUST create a <a href="http://www.w3.org/TR/performance-timeline/#performanceentrylist">PerformanceEntryList</a>
+  <li>Once the <a href="http://www.w3.org/TR/workers/#processing-model">Worker</a> or <a href="http://www.w3.org/TR/html5/browsers.html#create-a-document-object">Window object</a> is created, the user agent MUST create a <a href="http://www.w3.org/TR/performance-timeline/#performanceentrylist">PerformanceEntryList</a>
   <i>primary buffer</i> object to store the list
   of <a href="#performanceresourcetiming">PerformanceResourceTiming</a> resources.</li>
   <li>Set the <i>primary buffer</i> to a size of 150, unless otherwise specified
@@ -841,9 +837,7 @@ terms of a monotonic clock measuring time elapsed from the beginning of the navi
 <section id="privacy-security" class='informative'>
 <h2>Privacy and Security</h2>
 
-<p>The <a href="#performanceresourcetiming">PerformanceResourceTiming</a> interface
-exposes timing information for a resource to any web page that has included that
-resource. To limit the access to the <a href="#performanceresourcetiming">PerformanceResourceTiming</a> interface, the <a href="https://tools.ietf.org/html/rfc6454#section-5">same origin</a>
+<p>The <a href="#performanceresourcetiming">PerformanceResourceTiming</a> interface exposes timing information for a resource to any web page or worker that has requested that resource. To limit the access to the <a href="#performanceresourcetiming">PerformanceResourceTiming</a> interface, the <a href="https://tools.ietf.org/html/rfc6454#section-5">same origin</a>
 policy is enforced by default and certain attributes are set to zero, as described in <a href="#cross-origin-resources"></a>. Resource providers can
 explicitly allow all timing information to be collected for a resource by
 adding the <a href="#timing-allow-origin">Timing-Allow-Origin</a> HTTP response header, which specifies the

--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@ The <a href="#performanceresourcetiming">PerformanceResourceTiming</a> interface
   equal to the difference between <a href="#widl-PerformanceResourceTiming-responseEnd">responseEnd</a> and <a href="#startTime-attribute">startTime</a>, respectively.</dd>
 </dl>
 
-<dl title='interface PerformanceResourceTiming : PerformanceEntry' class='idl'>
+<dl title='[Exposed=(Window,Worker)] interface PerformanceResourceTiming : PerformanceEntry' class='idl'>
 
 <dt>readonly attribute DOMString initiatorType</dt>
 <dd>


### PR DESCRIPTION
This is continuation of w3c/performance-timeline#7.

- added Worker references in processing section
- cleaned up description to not limit RT to "current page"

/cc @plehegar I think this is all we need in this one, can you sanity check? Anything I'm missing?