### PR TITLE
Clarify initiatorType

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,12 +408,12 @@ On getting, the <dfn>initiatorType</dfn> attribute MUST return one of the follow
 </p>
 <ul>
 <li>The same value as the <code><a href="https://www.w3.org/TR/dom/#concept-element-local-name">localName</a></code> of that
-<code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code> [[!DOM]], if the initiator is an <code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code>;</li>
-<li><dfn id='css-resource'><code>"css"</code></dfn>, if the initiator is a CSS resource downloaded by the <code><a href="https://www.w3.org/TR/css-syntax-3/#consume-a-url-token">url()</a></code> syntax [[!CSS-SYNTAX-3]], such as <code>@import url()</code> or <code>background: url()</code>;</li>
+<code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code> [[!DOM]], if the request is a result of processing the <code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code>;</li>
+<li><dfn id='css-resource'><code>"css"</code></dfn>, if the request is a result of processing a CSS <code><a href="https://www.w3.org/TR/css-syntax-3/#consume-a-url-token">url()</a></code> directive [[!CSS-SYNTAX-3]], such as <code>@import url()</code> or <code>background: url()</code>;</li>
 <li><dfn id='navigation-resource'><code>"navigation"</code></dfn>, if the request is a <a href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>;</li>
-<li><dfn id='xhr-resource'><code>"xmlhttprequest"</code></dfn>, if the initiator is an XMLHttpRequest object [[!XMLHttpRequest]];</li>
-<li><dfn id='fetch-resource'><code>"fetch"</code></dfn>, if the initiator is <a href="https://fetch.spec.whatwg.org/#fetch-method">Fetch method</a> [[!Fetch]];</li>
-<li><dfn id='beacon-resource'><code>"beacon"</code></dfn>, if the initiator is <a href="https://www.w3.org/TR/beacon/#sec-sendBeacon-method">sendBeacon method</a> [[!Beacon]];</li>
+<li><dfn id='xhr-resource'><code>"xmlhttprequest"</code></dfn>, if the request is a result of processing an XMLHttpRequest object [[!XMLHttpRequest]];</li>
+<li><dfn id='fetch-resource'><code>"fetch"</code></dfn>, if the request is the result of processing the <a href="https://fetch.spec.whatwg.org/#fetch-method">Fetch method</a> [[!Fetch]];</li>
+<li><dfn id='beacon-resource'><code>"beacon"</code></dfn>, if the request is the result of processing the <a href="https://www.w3.org/TR/beacon/#sec-sendBeacon-method">sendBeacon method</a> [[!Beacon]];</li>
 <li><dfn id='other-resource'><code>"other"</code></dfn>, if none of the above conditions match.</li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -404,13 +404,17 @@ interface PerformanceResourceTiming : PerformanceEntry {
 </pre>
 
 <p dfn-for='PerformanceResourceTiming'>
-On getting, the <dfn>initiatorType</dfn> attribute MUST return one of the following <code>DOMString</code>:
+On getting, the <dfn>initiatorType</dfn> attribute MUST return one of the following <code>DOMString</code> values:
 </p>
 <ul>
 <li>The same value as the <code><a href="https://www.w3.org/TR/dom/#concept-element-local-name">localName</a></code> of that
-<code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code> [[!DOM]], if the initiator is an <code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code>.</li>
-<li><dfn id='css-resource'><code>"css"</code></dfn>, if the initiator is a CSS resource downloaded by the <code><a href="https://www.w3.org/TR/css-syntax-3/#consume-a-url-token">url()</a></code> syntax [[!CSS-SYNTAX-3]], such as <code>@import url()</code> or <code>background: url()</code>.</li>
-<li><dfn id='xhr-resource'><code>"xmlhttprequest"</code></dfn>, if the initiator is an XMLHttpRequest object [[!XMLHttpRequest]].</li>
+<code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code> [[!DOM]], if the initiator is an <code><a href="https://www.w3.org/TR/dom/#concept-element">element</a></code>;</li>
+<li><dfn id='css-resource'><code>"css"</code></dfn>, if the initiator is a CSS resource downloaded by the <code><a href="https://www.w3.org/TR/css-syntax-3/#consume-a-url-token">url()</a></code> syntax [[!CSS-SYNTAX-3]], such as <code>@import url()</code> or <code>background: url()</code>;</li>
+<li><dfn id='navigation-resource'><code>"navigation"</code></dfn>, if the request is a <a href="https://fetch.spec.whatwg.org/#navigation-request">navigation request</a>;</li>
+<li><dfn id='xhr-resource'><code>"xmlhttprequest"</code></dfn>, if the initiator is an XMLHttpRequest object [[!XMLHttpRequest]];</li>
+<li><dfn id='fetch-resource'><code>"fetch"</code></dfn>, if the initiator is <a href="https://fetch.spec.whatwg.org/#fetch-method">Fetch method</a> [[!Fetch]];</li>
+<li><dfn id='beacon-resource'><code>"beacon"</code></dfn>, if the initiator is <a href="https://www.w3.org/TR/beacon/#sec-sendBeacon-method">sendBeacon method</a> [[!Beacon]];</li>
+<li><dfn id='other-resource'><code>"other"</code></dfn>, if none of the above conditions match.</li>
 </ul>
 
 <p dfn-for='PerformanceResourceTiming'>On getting, the attribute <dfn>nextHopProtocol</dfn> returns the network protocol used to fetch the resource, as identified by the ALPN Protocol ID [[!RFC7301]]; resources retrieved from <a href="https://www.w3.org/TR/html5/browsers.html#relevant-application-cache">relevant application caches</a> or local resources, return an empty string. When a proxy is configured, if a tunnel connection is established then this attribute MUST return the ALPN Protocol ID of the tunneled protocol, otherwise it MUST return the ALPN Protocol ID of the first hop to the proxy. In order to have precisely one way to represent any ALPN protocol ID, the following additional constraints apply: octets in the ALPN protocol MUST NOT be percent-encoded if they are valid token characters except "%", and when using percent-encoding, uppercase hex digits MUST be used.</p>


### PR DESCRIPTION
Based on the discussion earlier today on the webperf call...

- Added: `fetch`, `beacon`, `navigation` as valid values. The last case is
  important for ServiceWorker cases; Nav Timing 2 will report same
  value.
- If none of the specified cases match, the default fallback is `other`.

Closes https://github.com/w3c/resource-timing/issues/69.