### PR TITLE
ABNF uses list extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,7 +701,7 @@ Set <a>resource timing buffer full flag</a> to false.
     </dfn> HTTP response header field can be used to communicate a policy
     indicating origin(s) that are allowed to see values of attributes that
     would have been zero due to the cross-origin restrictions. The header's
-    value is represented by the following ABNF [[!RFC5234]]:</p>
+    value is represented by the following ABNF [[!RFC5234]] (using <a href='https://tools.ietf.org/html/rfc7230#section-7'>List Extension</a>, [[!RFC7230]]):</p>
 
     <pre class="abnf">
       Timing-Allow-Origin = 1#( <a href='https://fetch.spec.whatwg.org/#origin-header'>origin-or-null</a> / <a href='https://fetch.spec.whatwg.org/#http-new-header-syntax'>wildcard</a> )


### PR DESCRIPTION
This should fix #99


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/resource-timing/abnf.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/resource-timing/177e382...88cf7ca.html)