### PR TITLE
Fix `connectEnd` definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@ On getting, the <dfn>connectEnd</dfn> attribute MUST return as follows:
 </p>
 <ol class="algorithm">
 <li>The same value as <a for="PerformanceResourceTiming">fetchStart</a>, if a <a href="https://tools.ietf.org/html/rfc7230#section-6.3">persistent connection</a> [[!RFC7230]] is used or the resource is retrieved from <a href="https://www.w3.org/TR/html5/browsers.html#relevant-application-cache">relevant application caches</a> or local resources.</li>
-<li>The time immediately after the user agent start establishing the connection to the server to retrieve the resource, if the last non-redirected <a href="https://www.w3.org/TR/html5/infrastructure.html#fetch">fetch</a> of the resource passes the <a>timing allow check</a> algorithm.
+<li>The time immediately after the user agent finish establishing the connection to the server to retrieve the resource, if the last non-redirected <a href="https://www.w3.org/TR/html5/infrastructure.html#fetch">fetch</a> of the resource passes the <a>timing allow check</a> algorithm.
 <p>The returned time MUST include the time interval to establish the transport connection, as well as other time intervals such as SSL handshake and SOCKS authentication.</p>
 <p>If the transport connection fails and the user agent reopens a connection, <a for='PerformanceResourceTiming'>connectEnd</a> SHOULD return the corresponding value of the new connection.</li>
 <li>zero, otherwise.</li>


### PR DESCRIPTION
Currently `connectEnd` is defined as the time after the UA started establishing a connection, which seems wrong. As an implementer, I'd interpret that as the time after a `connect()` call was called, which is wrong for non-blocking sockets.

The PR fixes that to clarify that it should be the timestamp after the connection finished.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/yoavweiss/resource-timing/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/resource-timing/fbdf3e0...yoavweiss:1ae302d.html)