### PR TITLE
Fix substeps ordering when buffer is full

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,7 +663,7 @@ Set <a>resource timing buffer full flag</a> to false.
 </ol>
 
 <p>
-  The attribute <dfn for='Performance'>onresourcetimingbufferfull</dfn> is the event handler for the <code>resourcetimingbufferfull</code> event.
+  The attribute <dfn for='Performance'>onresourcetimingbufferfull</dfn> is the event handler for the <code>resourcetimingbufferfull</code> event described below.
 </p>
 
 <p>To <dfn>add a PerformanceResourceTiming entry</dfn> (<i>new entry</i>) in the <a href='https://www.w3.org/TR/performance-timeline-2/#dfn-performance-entry-buffer'>performance entry buffer</a>, run the following steps:</p>
@@ -671,13 +671,13 @@ Set <a>resource timing buffer full flag</a> to false.
 <li>If <a>resource timing buffer current size</a> is less than <a>resource timing buffer size limit</a>, run the following substeps:
 <ol style='list-style-type: lower-latin;'>
 <li>Add <i>new entry</i> to the <a href='https://www.w3.org/TR/performance-timeline-2/#dfn-performance-entry-buffer'>performance entry buffer</a>.</li>
-<li>increase <a>resource timing buffer current size</a> by 1.</li>
+<li>Increase <a>resource timing buffer current size</a> by 1.</li>
 </ol>
 </li>
 <li>Otherwise, if the <a>resource timing buffer full flag</a> is false, run the following substeps:
 <ol style='list-style-type: lower-latin;'>
-<li><a href='https://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event'>fire a simple event</a> named <a for="Performance" data-lt="onresourcetimingbufferfull">resourcetimingbufferfull</a> at the Document, with its <code>bubbles</code> attribute initialized to true, and has no default action.</li>
-<li>set the <a>resource timing buffer full flag</a> to true.</li>
+<li>Set the <a>resource timing buffer full flag</a> to true.</li>
+<li><a href='https://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event'>Fire a simple event</a> named <code>resourcetimingbufferfull</code> at the Document, with its <code>bubbles</code> attribute initialized to true and with no default action.</li>
 </ol>
 </li>
 </ol>


### PR DESCRIPTION
This change adds consistency to the substep descriptions (all now start in uppercase), fixes a linking error for resourcetimingbufferfull, and fixes https://github.com/w3c/resource-timing/issues/134


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/resource-timing/pull/136.html" title="Last updated on Jan 3, 2018, 10:23 PM GMT (c00751f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/136/68372fd...npm1:c00751f.html" title="Last updated on Jan 3, 2018, 10:23 PM GMT (c00751f)">Diff</a>