### PR TITLE
Add a note regarding navigation preload in initiatorType

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,8 +450,8 @@ method</a> [[!BEACON]];</li>
 <aside data-dfn-for="PerformanceResourceTiming" class="note">
 The "navigation" initiator type includes all types of
 <a data-cite="!FETCH/#navigation-request">navigation requests</a>, including
-<a data-cite=
-"!service-workers-1/#ref-for-service-worker-registration-navigation-preload-enabled-flag%E2%91%A2">
+<a href=
+    "https://w3c.github.io/ServiceWorker/#ref-for-service-worker-registration-navigation-preload-enabled-flag%E2%91%A2">
 navigation preloads</a>.
 </aside>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the

--- a/index.html
+++ b/index.html
@@ -447,6 +447,13 @@ the <a data-cite="!BEACON/#sec-sendBeacon-method">sendBeacon
 method</a> [[!BEACON]];</li>
 <li><dfn>"other"</dfn>, if none of the above conditions match.</li>
 </ul>
+<aside data-dfn-for="PerformanceResourceTiming" class="note">
+The "navigation" initiator type includes all types of
+<a data-cite="!FETCH/#navigation-request">navigation requests</a>, including
+<a data-cite=
+"!service-workers-1/#ref-for-service-worker-registration-navigation-preload-enabled-flag%E2%91%A2">
+navigation preloads</a>.
+</aside>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 attribute <dfn>nextHopProtocol</dfn> returns the network protocol
 used to fetch the resource, as identified by the ALPN Protocol ID


### PR DESCRIPTION
Partially addresses https://github.com/w3c/resource-timing/issues/110 (covers the note, but not the tests)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/147.html" title="Last updated on Mar 6, 2018, 9:12 AM GMT (59c28ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/147/38b4edb...yoavweiss:59c28ce.html" title="Last updated on Mar 6, 2018, 9:12 AM GMT (59c28ce)">Diff</a>