### PR TITLE
Remove mention of default actions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -857,8 +857,7 @@ substeps:
 <li><a data-cite="!DOM/#concept-event-fire">Fire an event</a>
 named <code>resourcetimingbufferfull</code> at the <a data-cite=
 "!HR-TIME-2/#idl-def-performance">Performance</a> object, with its
-<code>bubbles</code> attribute initialized to true and with no
-default action.</li>
+<code>bubbles</code> attribute initialized to true.</li>
 </ol>
 </li>
 </ol>


### PR DESCRIPTION
As requested in issue #148.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/150.html" title="Last updated on Apr 24, 2018, 7:58 PM GMT (2414dd1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/150/784d351...2414dd1.html" title="Last updated on Apr 24, 2018, 7:58 PM GMT (2414dd1)">Diff</a>