### PR TITLE
Update recommended min UA Resource Timing buffer size to 250

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,7 +784,7 @@ Timeline</a> [[!PERFORMANCE-TIMELINE-2]]. This section extends the
 interface to allow controls over the number of
 <a>PerformanceResourceTiming</a> objects stored.</p>
 <p>The recommended minimum number of
-<a>PerformanceResourceTiming</a> objects is 150, though this may be
+<a>PerformanceResourceTiming</a> objects is 250, though this may be
 changed by the user agent. <a data-link-for=
 "Performance">setResourceTimingBufferSize</a> can be called to
 request a change to this limit.</p>
@@ -792,7 +792,7 @@ request a change to this limit.</p>
 environment</a> has:</p>
 <ul>
 <li>a <dfn>resource timing buffer size limit</dfn> which should
-initially be 150 or greater.</li>
+initially be 250 or greater.</li>
 <li>a <dfn>resource timing buffer current size</dfn> which is
 initially 0.</li>
 <li>a <dfn>resource timing buffer full flag</dfn> which is


### PR DESCRIPTION
I'd like to propose a modest change to the "recommended" initial UA RT buffer size of 150.

I've been doing some [research](https://nicj.net/resourcetiming-visibility-third-party-scripts-ads-and-page-weight/) into various aspects of ResourceTiming "visibility", and have found that over 14% of sites generate more than 150 resources in their main frame.

Here's a distribution of the Alexa Top 1000 sites and how many RT entries are from their main frame (from a [crawl](https://github.com/nicjansma/resourcetiming-visibility) with the buffer size increased in the head):

![image](https://user-images.githubusercontent.com/1004649/39097646-2eb68ce0-462d-11e8-8793-3b4e46c1cddf.png)

In this crawl, ~18% of sites would have hit the 150 limit (and only 15% of _those_ sites set the buffer size higher).

The 150 number is a UA-recommended limit, though I believe all current UAs choose 150.  It is not a spec requirement.

There's some previous discussion on whether 150 is appropriate, or if we should suggest UAs pick a higher default here: https://github.com/w3c/resource-timing/issues/89

The reason I think it should be increased is that:

* IIRC, we [initially chose](https://lists.w3.org/Archives/Public/public-web-perf/2012Apr/0034.html) 150 "back in the day" because many sites were nearing 100 resources or more, and we thought 150 would give enough buffer room to track all of those resources for the majority of sites
* Today, the [HTTPArchive](https://httparchive.org/reports/state-of-the-web#reqTotal) suggests a median of 80 resources and 90th percentile of 205 resources, but it's important to note that this is per-page, not per-frame.  I think it's safe to say the request count per page has increased since 2012, so it's a good time to re-evaluate the recommended minimum.
* While a site can update their buffer size beyond 150 by simply calling `setResourceTimingBufferSize`, third-party analytics scripts that may be loaded lower priority or after onload might want to increase this limit to ensure they capture all of the page's resources, but by the time they load, the buffer may already be full

It would still be up to UAs to decide if they want to chose 250, stay at 150, or a go for a lower initial limit (maybe even depending on the environment).

Changing to 250 will leave only 2.5% of the Alexa Top 1000 sites with a full buffer (more than 250 resources in the main frame).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/155.html" title="Last updated on May 30, 2018, 1:09 AM GMT (3a0db55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/155/ea8a875...3a0db55.html" title="Last updated on May 30, 2018, 1:09 AM GMT (3a0db55)">Diff</a>