### PR TITLE
Fix 'underlined' -> 'in parenthesis'

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,7 +924,7 @@ return <code>pass</code>.</p>
 <section id="processing-model">
 <h3>Processing Model</h3>
 <p>The following graph illustrates the timing attributes defined by
-the PerformanceResourceTiming interface. Attributes underlined may
+the PerformanceResourceTiming interface. Attributes in parenthesis may
 not be available when <a data-cite="!FETCH/#concept-fetch" data-lt=
 'fetch'>fetching</a> resources from different <a data-cite=
 "!RFC6454#section-5">origins</a>. User agents may perform internal


### PR DESCRIPTION
Small fix for https://github.com/w3c/resource-timing/issues/154


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/156.html" title="Last updated on May 17, 2018, 12:54 PM GMT (fedec69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/156/0b6e799...fedec69.html" title="Last updated on May 17, 2018, 12:54 PM GMT (fedec69)">Diff</a>