### PR TITLE
Remove the restriction for no-cors CSS subresources

### DIFF
--- a/index.html
+++ b/index.html
@@ -940,15 +940,7 @@ does not pass the <a>timing allow check</a> algorithm.</figcaption>
 style='margin-top: 1em'></figure>
 <p>For each resource <a data-cite=
 "!FETCH/#concept-fetch">fetched</a> by the current <a data-cite=
-"!HTML/#browsing-context">browsing context</a>, excluding resources
-fetched by cross-origin stylesheets fetched with
-<code>no-cors</code> policy, perform the following steps:</p>
-<p class="issue">Above cross-origin exclusion should be defined via
-Fetch registry: CSS needs to be defined in terms of Fetch and set
-some kind of "opaque request flag" for no-CORS CSS subresources. In
-turn, Resource Timing should interface with Fetch registry to
-surface resource fetch events.</p>
-<div class="issue" data-number="27"></div>
+"!HTML/#browsing-context">browsing context</a>, perform the following steps:</p>
 <ol data-link-for="PerformanceResourceTiming">
 <li><dfn data-lt="step-create-object">Create a new
 <a>PerformanceResourceTiming</a> object</dfn> and set


### PR DESCRIPTION
Closes #70 by removing the current restriction to align with all current implementations, and since the same information is already exposed by Service Workers.

cc @rniwa @digitarald @past for thoughts from Mozilla and WebKit


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/158.html" title="Last updated on May 18, 2018, 4:23 AM GMT (15b12ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/158/0b6e799...yoavweiss:15b12ac.html" title="Last updated on May 18, 2018, 4:23 AM GMT (15b12ac)">Diff</a>