### PR TITLE
Fire `resourcetimingbufferfull` asynchronously

### DIFF
--- a/index.html
+++ b/index.html
@@ -869,7 +869,7 @@ entry buffer</a>.</li>
 substeps:
 <ol style="list-style-type: lower-latin;">
 <li>Set <a>resource timing buffer full flag</a> to true.</li>
-<li>Queue a task to run <a>fire a buffer full event</a></li>
+<li>Queue a task to run <a>fire a buffer full event</a>.</li>
 </ol>
 <li>If <a>resource timing secondary buffer current size</a> is less than
 <a>resource timing buffer size limit</a>, add <i>new entry</i> to the
@@ -883,20 +883,26 @@ current size</a> by 1.</li>
 named <code>resourcetimingbufferfull</code> at the <a data-cite=
 "!HR-TIME-2/#idl-def-performance">Performance</a> object, with its
 <code>bubbles</code> attribute initialized to true.</li>
-<li>If <a>resource timing buffer size limit</a> minus <a>resource timing buffer
-current size</a> is not larger than <a>resource timing secondary buffer current
-size</a>, abort these steps.</li>
-<p class=note>This means that if the buffer does not have enough room for all
-the entries in the secondary buffer, none of them will be copied.</p>
-<li>For each <i>entry</i> in <a>secondary entry buffer</a>, add <i>entry</i> to
-<a data-cite='!PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
+<li>While <a>resource timing buffer current size</a> is smaller than
+<a>resource timing buffer size limit</a>, run the following substeps:
+<ol>
+<li>Let <i>entry</i> be the oldest <a>PerformanceResourceTiming</a> in
+<a>secondary entry buffer</a>.</li>
+<li>Add <i>entry</i> to <a
+data-cite='!PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
 entry buffer</a>.</li>
+<li>Increment <a>resource timing buffer current size</a> by 1.</li>
+</ol>
+<p class=note>This means that if the buffer does not have enough room for all
+the entries in the secondary buffer, some of them will not be copied.
+Developers should make sure that <code>resourcetimingbufferfull</code> event
+handlers call <code>clearResourceTimings</code> or extend the buffer
+sufficiently (by calling <code>setResourceTimingBufferSize</code>).</p>
 <li>Remove all objects from <a>secondary entry buffer</a>.</li>
-<li>Set <a>resource timing buffer current size</a> to <a>resource timing
-secondary buffer current size</a>.</li>
 <li>Set <a>resource timing secondary buffer current size</a> to 0.</li>
 </ol>
 </section>
+
 <section id="sec-cross-origin-resources">
 <h3>Cross-origin Resources</h3>
 <p data-link-for="PerformanceResourceTiming">Cross-origin resources

--- a/index.html
+++ b/index.html
@@ -797,15 +797,20 @@ interface to allow controls over the number of
 changed by the user agent. <a data-link-for=
 "Performance">setResourceTimingBufferSize</a> can be called to
 request a change to this limit.</p>
+
 <p>Each <a data-cite="!WEBIDL#es-environment">ECMAScript global
 environment</a> has:</p>
 <ul>
-<li>a <dfn>resource timing buffer size limit</dfn> which should
+<li>A <dfn>resource timing buffer size limit</dfn> which should
 initially be 250 or greater.</li>
-<li>a <dfn>resource timing buffer current size</dfn> which is
+<li>A <dfn>resource timing buffer current size</dfn> which is
 initially 0.</li>
-<li>a <dfn>resource timing buffer full flag</dfn> which is
+<li>A <dfn>resource timing buffer full flag</dfn> which is
 initially false.</li>
+<li>A <dfn>resource timing secondary buffer current size</dfn> which is
+initially 0.</li>
+<li>A <dfn>secondary entry buffer</dfn> to store <a>PerformanceEntry</a>
+objects that is initially empty.</li>
 </ul>
 <pre class="idl">partial interface Performance {
   void clearResourceTimings ();
@@ -817,13 +822,14 @@ initially false.</li>
 <p>The method <dfn>clearResourceTimings</dfn> runs the following
 steps:</p>
 <ol>
-<li>remove all <a>PerformanceResourceTiming</a> objects in the
+<li>Remove all <a>PerformanceResourceTiming</a> objects in the
 <a data-cite=
 '!PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
 entry buffer</a>.</li>
-<li>set <a>resource timing buffer current size</a> to 0.</li>
-<li>set <a>resource timing buffer full flag</a> to false.</li>
+<li>Set <a>resource timing buffer current size</a> to 0.</li>
+<li>Set <a>resource timing buffer full flag</a> to false.</li>
 </ol>
+
 <p>The <dfn>setResourceTimingBufferSize</dfn> method runs the
 following steps:</p>
 <ol>
@@ -838,14 +844,16 @@ entry buffer</a>.</li>
 timing buffer current size</a>, set <a>resource timing buffer full
 flag</a> to false.</li>
 </ol>
+
 <p>The attribute <dfn>onresourcetimingbufferfull</dfn> is the event
 handler for the <dfn>resourcetimingbufferfull</dfn> event described
 below.</p>
-<p>To <dfn>add a PerformanceResourceTiming entry</dfn> (<i>new
-entry</i>) in the <a data-cite=
+
+<p>To <dfn>add a PerformanceResourceTiming entry</dfn> into the <a data-cite=
 '!PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
 entry buffer</a>, run the following steps:</p>
 <ol>
+<li>Let <i>new entry</i> be the input <a>PerformanceEntry</a> to be added.
 <li>If <a>resource timing buffer current size</a> is less than
 <a>resource timing buffer size limit</a>, run the following
 substeps:
@@ -854,21 +862,39 @@ substeps:
 '!PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
 entry buffer</a>.</li>
 <li>Increase <a>resource timing buffer current size</a> by 1.</li>
+<li>Return.</li>
 </ol>
 </li>
-<li>If <a>resource timing buffer current size</a> is greater than
-or equal to <a>resource timing buffer size limit</a> and the
-<a>resource timing buffer full flag</a> is false, run the following
+<li>If <a>resource timing buffer full flag</a> is false, run the following
 substeps:
-<ol style='list-style-type: lower-latin;' data-link-for=
-"Performance">
-<li>Set the <a>resource timing buffer full flag</a> to true.</li>
+<ol style="list-style-type: lower-latin;">
+<li>Set <a>resource timing buffer full flag</a> to true.</li>
+<li>Queue a task to run <a>fire a buffer full event</a></li>
+</ol>
+<li>If <a>resource timing secondary buffer current size</a> is less than
+<a>resource timing buffer size limit</a>, add <i>new entry</i> to the
+<a>secondary entry buffer</a> and increment <a>resource timing secondary buffer
+current size</a> by 1.</li>
+</ol>
+
+<p>To <dfn>fire a buffer full event</dfn>, run the following steps:</p>
+<ol>
 <li><a data-cite="!DOM/#concept-event-fire">Fire an event</a>
 named <code>resourcetimingbufferfull</code> at the <a data-cite=
 "!HR-TIME-2/#idl-def-performance">Performance</a> object, with its
 <code>bubbles</code> attribute initialized to true.</li>
-</ol>
-</li>
+<li>If <a>resource timing buffer size limit</a> minus <a>resource timing buffer
+current size</a> is not larger than <a>resource timing secondary buffer current
+size</a>, abort these steps.</li>
+<p class=note>This means that if the buffer does not have enough room for all
+the entries in the secondary buffer, none of them will be copied.</p>
+<li>For each <i>entry</i> in <a>secondary entry buffer</a>, add <i>entry</i> to
+<a data-cite='!PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
+entry buffer</a>.</li>
+<li>Remove all objects from <a>secondary entry buffer</a>.</li>
+<li>Set <a>resource timing buffer current size</a> to <a>resource timing
+secondary buffer current size</a>.</li>
+<li>Set <a>resource timing secondary buffer current size</a> to 0.</li>
 </ol>
 </section>
 <section id="sec-cross-origin-resources">

--- a/index.html
+++ b/index.html
@@ -884,7 +884,8 @@ named <code>resourcetimingbufferfull</code> at the <a data-cite=
 "!HR-TIME-2/#idl-def-performance">Performance</a> object, with its
 <code>bubbles</code> attribute initialized to true.</li>
 <li>While <a>resource timing buffer current size</a> is smaller than
-<a>resource timing buffer size limit</a>, run the following substeps:
+<a>resource timing buffer size limit</a> and <a>secondary entry buffer</a> is
+not empty, run the following substeps:
 <ol>
 <li>Let <i>entry</i> be the oldest <a>PerformanceResourceTiming</a> in
 <a>secondary entry buffer</a>.</li>
@@ -892,6 +893,7 @@ named <code>resourcetimingbufferfull</code> at the <a data-cite=
 data-cite='!PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
 entry buffer</a>.</li>
 <li>Increment <a>resource timing buffer current size</a> by 1.</li>
+<li>Remove <i>entry</i> from <a>secondary entry buffer</a>.</li>
 </ol>
 <p class=note>This means that if the buffer does not have enough room for all
 the entries in the secondary buffer, some of them will not be copied.


### PR DESCRIPTION
Fixes #141 and #96 

This aligns the spec with WebKit's implementation to make sure that `resourcetimingbufferfull` can fire asynchronously without losing any entries in the process.

Tests are still missing.

@igrigorik @npm1 - can you take a look?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/163.html" title="Last updated on Sep 1, 2018, 8:20 PM GMT (059e4af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/163/709c54a...yoavweiss:059e4af.html" title="Last updated on Sep 1, 2018, 8:20 PM GMT (059e4af)">Diff</a>