### PR TITLE
Removed ! from performance entry buffer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,7 +794,7 @@ steps:</p>
 <ol>
 <li>remove all <a>PerformanceResourceTiming</a> objects in the
 <a data-cite=
-'!PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
+'PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
 entry buffer</a>.</li>
 <li>set <a>resource timing buffer current size</a> to 0.</li>
 <li>set <a>resource timing buffer full flag</a> to false.</li>
@@ -807,7 +807,7 @@ following steps:</p>
 than <a>resource timing buffer current size</a>, no
 <a>PerformanceResourceTiming</a> objects are to be removed from the
 <a data-cite=
-'!PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
+'PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
 entry buffer</a>.</li>
 <li>If the <i>maxSize</i> parameter is greater than <a>resource
 timing buffer current size</a>, set <a>resource timing buffer full
@@ -818,7 +818,7 @@ handler for the <dfn>resourcetimingbufferfull</dfn> event described
 below.</p>
 <p>To <dfn>add a PerformanceResourceTiming entry</dfn> (<i>new
 entry</i>) in the <a data-cite=
-'!PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
+'PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
 entry buffer</a>, run the following steps:</p>
 <ol>
 <li>If <a>resource timing buffer current size</a> is less than
@@ -826,7 +826,7 @@ entry buffer</a>, run the following steps:</p>
 substeps:
 <ol style="list-style-type: lower-latin;">
 <li>Add <i>new entry</i> to the <a data-cite=
-'!PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
+'PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer'>performance
 entry buffer</a>.</li>
 <li>Increase <a>resource timing buffer current size</a> by 1.</li>
 </ol>


### PR DESCRIPTION
Small editorial nits.

@marcoscaceres can you take look?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/171.html" title="Last updated on Oct 11, 2018, 10:43 AM GMT (188fa42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/171/cd2e3ec...yoavweiss:188fa42.html" title="Last updated on Oct 11, 2018, 10:43 AM GMT (188fa42)">Diff</a>