### PR TITLE
Use HTML's origin serialization, add note regarding TAO and redirects

### DIFF
--- a/index.html
+++ b/index.html
@@ -894,8 +894,8 @@ whether a resource's timing information can be shared with the
 <li>
 <p>If the <a>Timing-Allow-Origin</a> header value list contains a
 value which is byte-for-byte identical to the <a
-data-cite="HTML#ascii-serialisation-of-an-origin">ascii serialized value</a>
-of the <a>current document</a>'s <a data-cite="HTML#concept-origin">origin</a>,
+data-cite="HTML#ascii-serialisation-of-an-origin">serialisation</a>
+of the <a>current document</a>'s <a data-cite="DOM#concept-document-origin">origin</a>,
 or a wildcard ("<code>*</code>"), return <code>pass</code>.</p>
 </li>
 <li>Return <code>fail</code>.</li>

--- a/index.html
+++ b/index.html
@@ -900,7 +900,7 @@ or a wildcard ("<code>*</code>"), return <code>pass</code>.</p>
 </li>
 <li>Return <code>fail</code>.</li>
 </ol>
-<p class="issue" data-number="152">Above "timing allow check" algorithm should also verify that 
+<p class="issue" data-number="152">The above <a data-cite="#dfn-timing-allow-check">timing allow check</a> algorithm should also verify that 
 no cross-origin redirections were involved in the response, as that would 
 leak timing information about those origins.
 </p>

--- a/index.html
+++ b/index.html
@@ -893,13 +893,17 @@ whether a resource's timing information can be shared with the
 </li>
 <li>
 <p>If the <a>Timing-Allow-Origin</a> header value list contains a
-case-sensitive match for the value of the <code><a data-cite=
-"RFC6454#section-4" data-lt="http-origin">origin</a></code> of the
-<a>current document</a>, or a wildcard ("<code>*</code>"), return
-<code>pass</code>.</p>
+value which is byte-for-byte identical to the <a
+data-cite="HTML#ascii-serialisation-of-an-origin">ascii serialized value</a>
+of the <a>current document</a>'s <a data-cite="HTML#concept-origin">origin</a>,
+or a wildcard ("<code>*</code>"), return <code>pass</code>.</p>
 </li>
 <li>Return <code>fail</code>.</li>
 </ol>
+<p class="issue" data-number="152">Above "timing allow check" algorithm should also verify that 
+no cross-origin redirections were involved in the response, as that would 
+leak timing information about those origins.
+</p>
 </section>
 </section>
 </section>

--- a/index.html
+++ b/index.html
@@ -894,7 +894,7 @@ whether a resource's timing information can be shared with the
 <li>
 <p>If the <a>Timing-Allow-Origin</a> header value list contains a
 value which is byte-for-byte identical to the <a
-data-cite="HTML#ascii-serialisation-of-an-origin">serialisation</a>
+data-cite="HTML#ascii-serialisation-of-an-origin">serialization</a>
 of the <a>current document</a>'s <a data-cite="DOM#concept-document-origin">origin</a>,
 or a wildcard ("<code>*</code>"), return <code>pass</code>.</p>
 </li>


### PR DESCRIPTION
Addresses some of the concerns for https://github.com/w3c/resource-timing/issues/152


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/172.html" title="Last updated on Oct 21, 2018, 9:36 AM GMT (23c434b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/172/cd2e3ec...yoavweiss:23c434b.html" title="Last updated on Oct 21, 2018, 9:36 AM GMT (23c434b)">Diff</a>