### PR TITLE
add iana consideration section

### DIFF
--- a/index.html
+++ b/index.html
@@ -906,8 +906,8 @@ case-sensitive match for the value of the <code><a data-cite=
 <p>This section registers <a>Timing-Allow-Origin</a> as a <a href="https://tools.ietf.org/html/rfc3864#section-4.2.2">Provisional Message Header</a>.</p>
 <dl>
 <dt>Header field name:</dt><dd><pre class="abnf">Timing-Allow-Origin</pre></dd>
-<dt>Applicable protocol:</dt><dd><a href="https://tools.ietf.org/html/rfc2616">http</a></dd>
-<dt>Status:</dt><dd>standard</dd>
+<dt>Applicable protocol:</dt><dd>http</dd>
+<dt>Status:</dt><dd>provisional</dd>
 <dt>Author/Change controller:</dt><dd><a href="https://www.w3.org/">W3C</a></dd>
 <dt>Specification document:</dt><dd><a href="#sec-timing-allow-origin"></a></dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -901,6 +901,16 @@ case-sensitive match for the value of the <code><a data-cite=
 <li>Return <code>fail</code>.</li>
 </ol>
 </section>
+<section id="sec-iana-considerations">
+<h4>IANA Considerations</h4>
+<p>This section registers <a>Timing-Allow-Origin</a> as a <a href="https://tools.ietf.org/html/rfc3864#section-4.2.2">Provisional Message Header</a>.</p>
+<dl>
+<dt>Header field name:</dt><dd><pre class="abnf">Timing-Allow-Origin</pre></dd>
+<dt>Applicable protocol:</dt><dd><a href="https://tools.ietf.org/html/rfc2616">http</a></dd>
+<dt>Status:</dt><dd>standard</dd>
+<dt>Author/Change controller:</dt><dd><a href="https://www.w3.org/">W3C</a></dd>
+<dt>Specification document:</dt><dd><a href="#sec-timing-allow-origin"></a></dd>
+</dl>
 </section>
 </section>
 <section id="sec-process">


### PR DESCRIPTION
To register the Timing-Allow-Origin header.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/siusin/resource-timing/pull/176.html" title="Last updated on Oct 24, 2018, 4:14 PM GMT (9c003da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/176/cc2e16e...siusin:9c003da.html" title="Last updated on Oct 24, 2018, 4:14 PM GMT (9c003da)">Diff</a>