### PR TITLE
Fix "can add entry" algorithm typo which made it incorrect

### DIFF
--- a/index.html
+++ b/index.html
@@ -831,8 +831,8 @@ below.</p>
 <p>To check if <dfn>can add resource timing entry</dfn>, run the following
 steps:</p>
 <ol>
-<li>If <a>resource timing buffer size limit</a> is smaller than <a>resource
-timing buffer current size</a>, return true.</li>
+<li>If <a>resource timing buffer current size</a> is smaller than <a>resource
+timing buffer size limit</a>, return true.</li>
 <li>Return false.</li>
 </ol>
 


### PR DESCRIPTION
@cvazac pointed out that the current algorithm is incorrect. This fixes it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/184.html" title="Last updated on Dec 12, 2018, 4:35 PM GMT (7b74e0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/184/c94bdee...yoavweiss:7b74e0c.html" title="Last updated on Dec 12, 2018, 4:35 PM GMT (7b74e0c)">Diff</a>