### PR TITLE
Connection reuse does not imply DNS was not required

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,11 +524,12 @@ otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>The same value as <a>fetchStart</a>, if a <a href=
+<li>The same value as <a>fetchStart</a>, if no domain lookup was
+required to fetch the resources (e.g. due to the fact that a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
-connection</a> [[RFC7230]] is used or the resource is retrieved
-from <a data-cite="HTML#relevant-application-cache">relevant
-application caches</a> or local resources.</li>
+connection</a> [[RFC7230]] was used or in case the resource was
+retrieved from <a data-cite="HTML#relevant-application-cache">relevant
+application caches</a> or local resources).</li>
 <li>The time immediately after the user agent before the domain
 data retrieval from the domain information cache, if the user agent
 has the domain information in cache.</li>
@@ -1063,7 +1064,7 @@ local resources, including the <a href=
 "https://tools.ietf.org/html/rfc7234">HTTP cache</a> [[RFC7234]],
 go to step <a href="#dfn-step-request-start">14</a>.</li>
 <li>If no domain lookup is required, go to step <a href=
-"#dfn-step-connect-start">12</a>. Otherwise, immediately before a
+"#dfn-step-connect-start">14</a>. Otherwise, immediately before a
 user agent starts the domain name lookup, record the time as
 <a>domainLookupStart</a>.</li>
 <li>Record the time as <a>domainLookupEnd</a> immediately after the

--- a/index.html
+++ b/index.html
@@ -525,7 +525,7 @@ otherwise.</li>
 <dfn>domainLookupStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
 <li>The same value as <a>fetchStart</a>, if no domain lookup was
-required to fetch the resources (e.g. due to the fact that a <a href=
+required to fetch the resources (e.g. if a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
 connection</a> [[RFC7230]] was used or in case the resource was
 retrieved from <a data-cite="HTML#relevant-application-cache">relevant
@@ -542,15 +542,16 @@ the <a>timing allow check</a> algorithm.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupEnd</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>The same value as <a>fetchStart</a>, if a <a data-cite=
-"RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
-or the resource is retrieved from <a data-cite=
-"HTML#relevant-application-cache">relevant application caches</a>
-or local resources.</li>
+<li>The same value as <a>fetchStart</a>, if no domain lookup was
+required to fetch the resources (e.g. if a <a href=
+"https://tools.ietf.org/html/RFC7230#section-6.3">persistent
+connection</a> [[RFC7230]] was used or in case the resource was
+retrieved from <a data-cite="HTML#relevant-application-cache">relevant
+application caches</a> or local resources).</li>
 <li>The time immediately after the user agent ends the domain data
 retrieval from the domain information cache, if the user agent has
 the domain information in cache.</li>
-<li>The time immediately before the user agent finishes the domain
+<li>The time immediately after the user agent finishes the domain
 name lookup for the resource, if the last non-redirected
 <a data-cite="FETCH#concept-fetch">fetch</a> of the resource passes
 the <a>timing allow check</a> algorithm.</li>


### PR DESCRIPTION
Closes #160 
As discussed on the call, this is not currently testable in WPT infrastructure. I'm planning to open an issue to keep track of tests for this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/185.html" title="Last updated on Dec 19, 2018, 11:24 PM UTC (78bd09f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/185/13d5a2e...yoavweiss:78bd09f.html" title="Last updated on Dec 19, 2018, 11:24 PM UTC (78bd09f)">Diff</a>