### PR TITLE
Clarify that connectStart/connectEnd refer to the latest connection retry

### DIFF
--- a/index.html
+++ b/index.html
@@ -1076,15 +1076,17 @@ resource passes the <a>timing allow check</a> record the time as
 connection is used to <a data-cite="FETCH#concept-fetch">fetch</a>
 the resource</dfn>, let <a>connectStart</a> and <a>connectEnd</a>
 be the same value of <a>domainLookupEnd</a>. Otherwise, record the
-time as <a>connectStart</a> immediately before initiating the latest
-successful connection to the server and record the time as
-<a>connectEnd</a> immediately after the latest successful connection to
-the server or the proxy is established. A user agent may need multiple
-retries before this time. Once connection is established set the value
-of <a>nextHopProtocol</a> to the ALPN ID used by the connection. If a
-connection can not be established, record the time up to the
-connection failure as <a>connectEnd</a> and go to <a href=
-"#dfn-step-final-record">step 17</a>.</li>
+time as <a>connectStart</a> immediately before initiating a successful
+connection to the server and record the time as <a>connectEnd</a>
+immediately after the successful connection to the server or proxy is
+established. A user agent may need multiple retries to establish a
+successful connection and should reflect the timestamps for the
+successful connection only.
+Once connection is established set the value of <a>nextHopProtocol</a>
+to the ALPN ID used by the connection. If a connection can not be
+established, record the time up to the connection failure as
+<a>connectEnd</a> and go to <a href= "#dfn-step-final-record">step
+17</a>.</li>
 <li>The user agent MUST set the <a>secureConnectionStart</a>
 attribute as follows:
 <ol>

--- a/index.html
+++ b/index.html
@@ -1076,12 +1076,12 @@ resource passes the <a>timing allow check</a> record the time as
 connection is used to <a data-cite="FETCH#concept-fetch">fetch</a>
 the resource</dfn>, let <a>connectStart</a> and <a>connectEnd</a>
 be the same value of <a>domainLookupEnd</a>. Otherwise, record the
-time as <a>connectStart</a> immediately before initiating the
-connection to the server and record the time as <a>connectEnd</a>
-immediately after the connection to the server or the proxy is
-established. A user agent may need multiple retries before this
-time. Once connection is established set the value of
-<a>nextHopProtocol</a> to the ALPN ID used by the connection. If a
+time as <a>connectStart</a> immediately before initiating the latest
+successful connection to the server and record the time as
+<a>connectEnd</a> immediately after the latest successful connection to
+the server or the proxy is established. A user agent may need multiple
+retries before this time. Once connection is established set the value
+of <a>nextHopProtocol</a> to the ALPN ID used by the connection. If a
 connection can not be established, record the time up to the
 connection failure as <a>connectEnd</a> and go to <a href=
 "#dfn-step-final-record">step 17</a>.</li>


### PR DESCRIPTION
closes https://github.com/w3c/resource-timing/issues/123


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/189.html" title="Last updated on Dec 19, 2018, 4:40 PM UTC (536548a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/189/13d5a2e...yoavweiss:536548a.html" title="Last updated on Dec 19, 2018, 4:40 PM UTC (536548a)">Diff</a>