### PR TITLE
HTTP over QUIC is now HTTP/3

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,10 +454,9 @@ non-registered protocol, the user agent MUST use the ALPN
 negotiated value if any. If ALPN was not used for protocol
 negotiations, the user agent MAY use another descriptive
 string.</p>
-<p class="note">The "hq" ALPN ID is defined for the final version
-of the HTTP over QUIC protocol in the <a href=
-"https://tools.ietf.org/html/draft-ietf-quic-http-11#section-9.1">HTTP
-over QUIC Internet Draft</a>.</p>
+<p class="note">The "h3" ALPN ID is defined for the final version
+of the HTTP/3 protocol in the <a href=
+"https://tools.ietf.org/html/draft-ietf-quic-http-17#section-10.1">HTTP/3 Internet Draft</a>.</p>
 <p>Note that the <a data-link-for=
 "PerformanceResourceTiming">nextHopProtocol</a> attribute is
 intended to identify the network protocol in use for the fetch


### PR DESCRIPTION
@yoavweiss This got renamed formally in draft 17.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/LPardue/resource-timing/pull/191.html" title="Last updated on Jan 3, 2019, 1:44 PM UTC (ce58d8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/191/3e08125...LPardue:ce58d8e.html" title="Last updated on Jan 3, 2019, 1:44 PM UTC (ce58d8e)">Diff</a>