### PR TITLE
Force TAO check on all fetches, not just the last non-redirected one

### DIFF
--- a/index.html
+++ b/index.html
@@ -1066,11 +1066,12 @@ be the same value as <a>fetchStart</a>.</li>
 reuse the data from another existing or completed <a data-cite=
 "FETCH#concept-fetch">fetch</a> initiated from the <a>current
 document</a></dfn>, abort the remaining steps.</li>
-<li>If any <a data-cite="FETCH#concept-fetch">fetch</a> of the resource
-fails the <a>timing allow check</a>, the user agent MUST set
-<a>redirectStart</a>, <a>redirectEnd</a>, <a>domainLookupStart</a>,
-<a>domainLookupEnd</a>, <a>connectStart</a>, <a>connectEnd</a>,
-<a>requestStart</a>, <a>responseStart</a> and
+<li>If any request in the resource <a
+data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
+redirects) fails the <a>timing allow check</a> algorithm, the user
+agent MUST set <a>redirectStart</a>, <a>redirectEnd</a>,
+<a>domainLookupStart</a>, <a>domainLookupEnd</a>, <a>connectStart</a>,
+<a>connectEnd</a>, <a>requestStart</a>, <a>responseStart</a> and
 <a>secureConnectionStart</a> to zero and go to step <a href=
 "#dfn-step-response-end">16</a>.</li>
 <li>Let <a>domainLookupStart</a>, <a>domainLookupEnd</a>,

--- a/index.html
+++ b/index.html
@@ -537,8 +537,9 @@ otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
-resource fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if any request in the resource <a
+data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
+redirects) fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if no domain lookup was
 required to fetch the resources (e.g. if a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
@@ -554,8 +555,9 @@ name lookup for the resource, otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupEnd</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
-resource fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if any request in the resource <a
+data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
+redirects) fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if no domain lookup was
 required to fetch the resources (e.g. if a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
@@ -571,8 +573,9 @@ name lookup for the resource, otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>connectStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
-resource fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if any request in the resource <a
+data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
+redirects) fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -590,8 +593,9 @@ corresponding value of the new connection.</p>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>connectEnd</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
-resource fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if any request in the resource <a
+data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
+redirects) fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -612,8 +616,10 @@ corresponding value of the new connection.</p>
 <dfn>secureConnectionStart</dfn> attribute MUST return as
 follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
-resource fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if a secure transport is not used or if any request in the
+resource <a data-cite="FETCH#concept-fetch">fetch</a>'s request-chain
+(including redirects) fails the <a>timing allow check</a> algorithm.
+</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -628,9 +634,9 @@ process to secure the current connection, otherwise.</li>
 <li>The time immediately before the user agent starts requesting
 the resource from the server, or from <a data-cite=
 "HTML#relevant-application-cache">relevant application caches</a>
-or from local resources, if all <a data-cite=
-"FETCH#concept-fetch">fetches</a> of the resource pass the
-<a>timing allow check</a> algorithm.
+or from local resources, if all requests in the resource <a data-cite=
+"FETCH#concept-fetch">fetch</a>'s request-chain (including redirects)
+pass the <a>timing allow check</a> algorithm.
 <p>If the transport connection fails after a request is sent and
 the user agent reopens a connection and resend the request,
 <a data-link-for="PerformanceResourceTiming">requestStart</a> MUST
@@ -659,8 +665,9 @@ receives the first byte of the response (e.g. frame header bytes
 for HTTP/2, or response status line for HTTP/1.x) from
 <a data-cite="HTML#relevant-application-cache">relevant application
 caches</a>, or from local resources or from the server if all
-<a data-cite="FETCH#concept-fetch">fetches</a> of the
-resource pass the <a>timing allow check</a> algorithm.</li>
+requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
+request-chain (including redirects) pass the <a>timing allow check</a>
+algorithm.</li>
 <li>zero, otherwise.</li>
 </ol>
 <aside class="note">
@@ -697,8 +704,9 @@ to a network error.</li>
 "FETCH#http-network-fetch">HTTP-network fetch</a>, consumed by the
 response header fields and the response <a data-cite=
 "RFC7230#section-3.3">payload body</a> [[RFC7230]] if all
-<a data-cite="FETCH#concept-fetch">fetches</a> of the
-resource pass the <a>timing allow check</a> algorithm.
+requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
+request-chain (including redirects) pass the <a>timing allow check</a>
+algorithm.
 <p>If there are HTTP redirects or <a data-cite="HTML#or-equivalent"
 data-lt='HTTP response codes equivalence'>equivalent</a> when
 navigating and if all the redirects or equivalent are from the same
@@ -734,8 +742,8 @@ caches</a> or from local resources.</li>
 fetch, of the <a data-cite="RFC7230#section-3.3">payload body</a>
 [[RFC7230]], prior to removing any applied <a data-cite=
 "RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if all
-<a data-cite="FETCH#concept-fetch">fetches</a> of
-the resource pass the <a>timing allow check</a> algorithm.</li>
+requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
+request-chain (including redirects) pass the <a>timing allow check</a> algorithm.</li>
 <li>The size, in octets, of the <a data-cite=
 "RFC7230#section-3.3">payload body</a> prior to removing any
 applied <a data-cite="RFC7231#section-3.1.2.1">content-codings</a>
@@ -757,8 +765,8 @@ etc.</aside>
 fetch, of the <a data-cite="RFC7230#section-3.3">message body</a>
 [[RFC7230]], after removing any applied <a data-cite=
 "RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if all
-<a data-cite="FETCH#concept-fetch">fetches</a> of
-the resource pass the <a>timing allow check</a> algorithm.</li>
+requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
+request-chain (including redirects) pass the <a>timing allow check</a> algorithm.</li>
 <li>The size, in octets, of the <a data-cite=
 "RFC7230#section-3.3">payload</a> after removing any applied
 <a data-cite="RFC7231#section-3.1.2.1">content-codings</a>, if the

--- a/index.html
+++ b/index.html
@@ -537,9 +537,8 @@ otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if the last non-redirected
-<a data-cite="FETCH#concept-fetch">fetch</a> of the resource fails the 
-<a>timing allow check</a> algorithm.</li>
+<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
+resource fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if no domain lookup was
 required to fetch the resources (e.g. if a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
@@ -555,9 +554,8 @@ name lookup for the resource, otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupEnd</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if the last non-redirected
-<a data-cite="FETCH#concept-fetch">fetch</a> of the resource fails the 
-<a>timing allow check</a> algorithm.</li>
+<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
+resource fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if no domain lookup was
 required to fetch the resources (e.g. if a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
@@ -573,9 +571,8 @@ name lookup for the resource, otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>connectStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if the last non-redirected
-<a data-cite="FETCH#concept-fetch">fetch</a> of the resource fails the 
-<a>timing allow check</a> algorithm.</li>
+<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
+resource fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -593,9 +590,8 @@ corresponding value of the new connection.</p>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>connectEnd</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if the last non-redirected
-<a data-cite="FETCH#concept-fetch">fetch</a> of the resource fails the 
-<a>timing allow check</a> algorithm.</li>
+<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
+resource fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -616,9 +612,8 @@ corresponding value of the new connection.</p>
 <dfn>secureConnectionStart</dfn> attribute MUST return as
 follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if a secure transport is not used or the last non-redirected
-<a data-cite="FETCH#concept-fetch">fetch</a> of the resource fails the 
-<a>timing allow check</a> algorithm.</li>
+<li>Zero, if any <a data-cite="FETCH#concept-fetch">fetch</a> of the
+resource fails the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -633,8 +628,8 @@ process to secure the current connection, otherwise.</li>
 <li>The time immediately before the user agent starts requesting
 the resource from the server, or from <a data-cite=
 "HTML#relevant-application-cache">relevant application caches</a>
-or from local resources, if the last non-redirected <a data-cite=
-"FETCH#concept-fetch">fetch</a> of the resource passes the
+or from local resources, if all <a data-cite=
+"FETCH#concept-fetch">fetches</a> of the resource pass the
 <a>timing allow check</a> algorithm.
 <p>If the transport connection fails after a request is sent and
 the user agent reopens a connection and resend the request,
@@ -663,9 +658,9 @@ encapsulation.</li>
 receives the first byte of the response (e.g. frame header bytes
 for HTTP/2, or response status line for HTTP/1.x) from
 <a data-cite="HTML#relevant-application-cache">relevant application
-caches</a>, or from local resources or from the server if the last
-non-redirected <a data-cite="FETCH#concept-fetch">fetch</a> of the
-resource passes the <a>timing allow check</a> algorithm.</li>
+caches</a>, or from local resources or from the server if all
+<a data-cite="FETCH#concept-fetch">fetches</a> of the
+resource pass the <a>timing allow check</a> algorithm.</li>
 <li>zero, otherwise.</li>
 </ol>
 <aside class="note">
@@ -701,9 +696,9 @@ to a network error.</li>
 <li>the size, in octets received from a <a data-cite=
 "FETCH#http-network-fetch">HTTP-network fetch</a>, consumed by the
 response header fields and the response <a data-cite=
-"RFC7230#section-3.3">payload body</a> [[RFC7230]] if the last
-non-redirected <a data-cite="FETCH#concept-fetch">fetch</a> of the
-resource passes the <a>timing allow check</a> algorithm.
+"RFC7230#section-3.3">payload body</a> [[RFC7230]] if all
+<a data-cite="FETCH#concept-fetch">fetches</a> of the
+resource pass the <a>timing allow check</a> algorithm.
 <p>If there are HTTP redirects or <a data-cite="HTML#or-equivalent"
 data-lt='HTTP response codes equivalence'>equivalent</a> when
 navigating and if all the redirects or equivalent are from the same
@@ -738,9 +733,9 @@ caches</a> or from local resources.</li>
 "FETCH#http-network-or-cache-fetch">HTTP-network-or-cache</a>
 fetch, of the <a data-cite="RFC7230#section-3.3">payload body</a>
 [[RFC7230]], prior to removing any applied <a data-cite=
-"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if the
-last non-redirected <a data-cite="FETCH#concept-fetch">fetch</a> of
-the resource passes the <a>timing allow check</a> algorithm.</li>
+"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if all
+<a data-cite="FETCH#concept-fetch">fetches</a> of
+the resource pass the <a>timing allow check</a> algorithm.</li>
 <li>The size, in octets, of the <a data-cite=
 "RFC7230#section-3.3">payload body</a> prior to removing any
 applied <a data-cite="RFC7231#section-3.1.2.1">content-codings</a>
@@ -761,9 +756,9 @@ etc.</aside>
 "FETCH#http-network-or-cache-fetch">HTTP-network-or-cache</a>
 fetch, of the <a data-cite="RFC7230#section-3.3">message body</a>
 [[RFC7230]], after removing any applied <a data-cite=
-"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if the
-last non-redirected <a data-cite="FETCH#concept-fetch">fetch</a> of
-the resource passes the <a>timing allow check</a> algorithm.</li>
+"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if all
+<a data-cite="FETCH#concept-fetch">fetches</a> of
+the resource pass the <a>timing allow check</a> algorithm.</li>
 <li>The size, in octets, of the <a data-cite=
 "RFC7230#section-3.3">payload</a> after removing any applied
 <a data-cite="RFC7231#section-3.1.2.1">content-codings</a>, if the
@@ -1063,10 +1058,9 @@ be the same value as <a>fetchStart</a>.</li>
 reuse the data from another existing or completed <a data-cite=
 "FETCH#concept-fetch">fetch</a> initiated from the <a>current
 document</a></dfn>, abort the remaining steps.</li>
-<li>If the last non-redirected <a data-cite=
-"FETCH#concept-fetch">fetch</a> of the resource fails the <a>timing
-allow check</a>, the user agent MUST set <a>redirectStart</a>,
-<a>redirectEnd</a>, <a>domainLookupStart</a>,
+<li>If any <a data-cite="FETCH#concept-fetch">fetch</a> of the resource
+fails the <a>timing allow check</a>, the user agent MUST set
+<a>redirectStart</a>, <a>redirectEnd</a>, <a>domainLookupStart</a>,
 <a>domainLookupEnd</a>, <a>connectStart</a>, <a>connectEnd</a>,
 <a>requestStart</a>, <a>responseStart</a> and
 <a>secureConnectionStart</a> to zero and go to step <a href=


### PR DESCRIPTION
As @npm1 pointed out, we can handwave our way around the issues pointed out in https://github.com/w3c/resource-timing/issues/173 and #152 by applying TAO check to all related fetches, rather than just the last non-redirected one (in a handwavy way, but better than nothing).

Some tests for this are at https://github.com/web-platform-tests/wpt/pull/13518. I'll add more.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/196.html" title="Last updated on Jan 10, 2019, 4:49 PM UTC (43fc224)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/196/47f8c68...yoavweiss:43fc224.html" title="Last updated on Jan 10, 2019, 4:49 PM UTC (43fc224)">Diff</a>