### PR TITLE
Improve TAO definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -952,11 +952,19 @@ whether a resource's timing information can be shared with the
 <a>current document</a>, is as follows:</p>
 <ol>
     <li><p>Let <var>tainted</var> be false.</p></li>
-    <li><p>For each request in the resource <a
+    <li><p>If the resource's <a>Request</a>'s <a
+    data-cite="FETCH#concept-request-window">window</a> is not an <a
+    data-cite="HTML/webapppapis.html#environment-settings-object">environment
+    settings object</a>, set tainted to true</p></li>
+    <li><p>For each <var>request</var> in the resource <a
     data-cite="FETCH#concept-fetch">fetch</a> redirection-chain:</p>
         <ol>
-            <li><p>If the request is <a>cross-origin</a>, set
-            <var>tainted</var> to true.</p></li>
+            <li><p>If <var>tainted</var> is false and <var>request</var>
+            is <a>cross-origin</a> when compared to the resource's
+            <a>Request</a>'s <a
+            data-cite="FETCH#concept-request-window">window</a>'s
+            <a data-cite="HTML/webappapis.html#concept-settings-object-origin">origin</a>,
+            set <var>tainted</var> to true.</p></li>
             <li><p>If the <a>Timing-Allow-Origin</a> header value list
             does not contain a value which is byte-for-byte identical to
             the <a

--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@ example, a resource could originate from XMLHttpRequest objects
 object, embed, and link with the link type of stylesheet, and SVG
 elements [[SVG11]] such as svg.</p>
 <p>The term <dfn>cross-origin</dfn> is used to mean non
-<a data-cite="RFC6454#section-5">same origin</a>.</p>
+<a data-cite="HTML#same-origin">same origin</a>.</p>
 <p>The term <dfn>current document</dfn> refers to the document
 associated with the <a data-cite=
 "HTML#concept-document-window">Window object's newest Document
@@ -694,10 +694,9 @@ response header fields and the response <a data-cite=
 resource passes the <a>timing allow check</a> algorithm.
 <p>If there are HTTP redirects or <a data-cite="HTML#or-equivalent"
 data-lt='HTTP response codes equivalence'>equivalent</a> when
-navigating and if all the redirects or equivalent are from the same
-<a data-cite="RFC6454#section-4">origin</a> [[RFC6454]], this
-attribute SHOULD include the HTTP overhead of incurred
-redirects.</p>
+navigating and if all the redirects or equivalent are <a
+data-cite="HTML#same-origin">same origin</a>, this attribute SHOULD
+include the HTTP overhead of incurred redirects.</p>
 <p>This attribute SHOULD include HTTP overhead (such as HTTP/1.1
 chunked encoding and whitespace around header fields, including
 newlines, and <a href=
@@ -941,7 +940,7 @@ by the following ABNF [[RFC5234]] (using <a data-cite=
       Timing-Allow-Origin = 1#( <a data-cite=
 "FETCH#origin-header">origin-or-null</a> / <a data-cite=
 "FETCH#http-new-header-syntax">wildcard</a> )
-    </pre>
+</pre>
 <p>The sender MAY generate multiple <a>Timing-Allow-Origin</a>
 header fields. The recipient MAY combine multiple
 <a>Timing-Allow-Origin</a> header fields by appending each
@@ -951,31 +950,33 @@ separated by a comma.</p>
 whether a resource's timing information can be shared with the
 <a>current document</a>, is as follows:</p>
 <ol>
-    <li><p>Let <var>tainted</var> be false.</p></li>
-    <li><p>If the resource's <a>Request</a>'s <a
-    data-cite="FETCH#concept-request-window">window</a> is not an <a
-    data-cite="HTML/webapppapis.html#environment-settings-object">environment
-    settings object</a>, set tainted to true</p></li>
-    <li><p>For each <var>request</var> in the resource <a
-    data-cite="FETCH#concept-fetch">fetch</a> redirection-chain:</p>
-        <ol>
-            <li><p>If <var>tainted</var> is false and <var>request</var>
-            is <a>cross-origin</a> when compared to the resource's
-            <a>Request</a>'s <a
-            data-cite="FETCH#concept-request-window">window</a>'s
-            <a data-cite="HTML/webappapis.html#concept-settings-object-origin">origin</a>,
-            set <var>tainted</var> to true.</p></li>
-            <li><p>If the <a>Timing-Allow-Origin</a> header value list
-            does not contain a value which is byte-for-byte identical to
-            the <a
-            data-cite="HTML#ascii-serialisation-of-an-origin">serialization</a>
-            of the <a>current document</a>'s <a
-            data-cite="DOM#concept-document-origin">origin</a>, nor a
-            wildcard ("<code>*</code>"), and <var>tainted</var> is
-            true, return <code>fail</code>.</p></li>
-        </ol>
-    <li><p>Return pass.</p></li>
+  <li><p>If the resource's <a>Request</a>'s <a
+  data-cite="FETCH#concept-request-window">window</a> is not an <a
+  data-cite="HTML/webapppapis.html#environment-settings-object">environment
+  settings object</a>, return <code>fail</code>.</p></li>
+  <li><p>For each <var>request</var> in the resource <a
+  data-cite="FETCH#concept-fetch">fetch</a> redirection-chain:</p>
+    <ol>
+      <li><p>If <var>request</var> is not <a>cross-origin</a> when compared to the
+      resource's <a>Request</a>'s <a
+      data-cite="FETCH#concept-request-window">window</a>'s
+      <a data-cite="HTML/webappapis.html#concept-settings-object-origin">origin</a>,
+      continue to the next <var>request</var>.</p></li>
+      <li><p>If the <a>Timing-Allow-Origin</a> header value list
+      does not contain a value which is byte-for-byte identical to
+      the <a
+      data-cite="HTML#ascii-serialisation-of-an-origin">serialization</a>
+      of the <a>current document</a>'s <a
+      data-cite="DOM#concept-document-origin">origin</a>, nor a
+      wildcard ("<code>*</code>"), return <code>fail</code>.</p></li>
+    </ol>
+  <li><p>Return <code>pass</code>.</p></li>
 </ol>
+<p class=note>The above definition does not fully align Timing-Allow-Origin's
+processing with CORS processing. Specifically, if a redirection chain includes
+a cross-origin resource followed by same-origin resources without an explicit
+opt-in, TAO will pass while CORS will fail. Future iterations of this
+specification may attempt to unite those definitions.</p>
 </section>
 <section id="sec-iana-considerations">
 <h4>IANA Considerations</h4>
@@ -996,9 +997,8 @@ whether a resource's timing information can be shared with the
 <p>The following graph illustrates the timing attributes defined by
 the PerformanceResourceTiming interface. Attributes in parenthesis
 may not be available when <a data-cite="FETCH#concept-fetch"
-data-lt='fetch'>fetching</a> resources from different <a data-cite=
-"RFC6454#section-5">origins</a>. User agents may perform internal
-processing in between timings, which allow for non-normative
+data-lt='fetch'>fetching</a> <a>cross-origin</a> resources. User agents may 
+perform internal processing in between timings, which allow for non-normative
 intervals between timings.</p>
 <figure data-lt='Timing attributes'>
 <figcaption>This figure illustrates the timing attributes defined
@@ -1154,19 +1154,17 @@ is not set, set it to the current time. <dfn data-lt=
 <a data-cite="HTML#or-equivalent" data-lt=
 'HTTP response codes equivalence'>equivalent</a>, then
 <ol>
-<li>If the current resource and the redirected resource are not
-from the <a data-cite="RFC6454#section-5">same origin</a> as the
-<a>current document</a>, and the <a>timing allow check</a>
-algorithm fails for either resource, set <a>redirectStart</a> and
-<a>redirectEnd</a> to 0. Then, return to step <a href=
-"#dfn-step-fetch-start">5</a> with the new resource.</li>
+<li>If the current resource fails the <a>timing allow check</a>
+algorithm, set <a>redirectStart</a> and <a>redirectEnd</a> to 0.
+Then, return to step <a href="#dfn-step-fetch-start">7</a> with the
+redirected resource.</li>
 <li>If the value of redirectStart is not set, let it be the value
 of fetchStart.</li>
 <li>Let redirectEnd be the value of responseEnd.</li>
 <li>Set all the attributes in the <a>PerformanceResourceTiming</a>
 object to 0 except <a>startTime</a>, <a>redirectStart</a>,
 <a>redirectEnd</a>, and <a>initiatorType</a>.</li>
-<li>Return to step <a href="#dfn-step-fetch-start">5</a> with the
+<li>Return to step <a href="#dfn-step-fetch-start">7</a> with the
 new resource.</li>
 </ol>
 </li>
@@ -1206,7 +1204,7 @@ navigation.</p>
 information for a resource to any web page or worker that has
 requested that resource. To limit the access to the
 <a>PerformanceResourceTiming</a> interface, the <a data-cite=
-"RFC6454#section-5">same origin</a> policy is enforced by default
+"HTML#same-origin">same origin</a> policy is enforced by default
 and certain attributes are set to zero, as described in <a href=
 "#sec-cross-origin-resources"></a>. Resource providers can
 explicitly allow all timing information to be collected for a

--- a/index.html
+++ b/index.html
@@ -957,7 +957,9 @@ whether a resource's timing information can be shared with the
   <li><p>For each <var>request</var> in the resource <a
   data-cite="FETCH#concept-fetch">fetch</a> redirection-chain:</p>
     <ol>
-      <li><p>If <var>request</var> is not <a>cross-origin</a> when compared to the
+      <li><p>If <var>request</var>'s <a
+      data-cite="FETCH#concept-request-origin">origin</a> is <a
+      data-cite="HTML#same-origin">same-origin</a> when compared to the
       resource's <a>Request</a>'s <a
       data-cite="FETCH#concept-request-window">window</a>'s
       <a data-cite="HTML/webappapis.html#concept-settings-object-origin">origin</a>,

--- a/index.html
+++ b/index.html
@@ -940,7 +940,7 @@ by the following ABNF [[RFC5234]] (using <a data-cite=
       Timing-Allow-Origin = 1#( <a data-cite=
 "FETCH#origin-header">origin-or-null</a> / <a data-cite=
 "FETCH#http-new-header-syntax">wildcard</a> )
-</pre>
+    </pre>
 <p>The sender MAY generate multiple <a>Timing-Allow-Origin</a>
 header fields. The recipient MAY combine multiple
 <a>Timing-Allow-Origin</a> header fields by appending each
@@ -1054,8 +1054,8 @@ is fired</a> at the active worker record the time as
 <a>workerStart</a>. Otherwise, if there is no matching
 <a data-cite="service-workers-1#dfn-service-worker-registration">service
 worker registration</a>, set <a>workerStart</a> value to zero.</li>
-<li><dfn data-lt="step-fetch-start">Immediately before a user agent
-starts the <a data-cite="FETCH#concept-fetch" data-lt=
+<li><em>Fetch start:</em> <dfn data-lt="step-fetch-start">Immediately before a
+user agent starts the <a data-cite="FETCH#concept-fetch" data-lt=
 'fetch'>fetching process</a></dfn>, record the <a>current time</a>
 as <a>fetchStart</a>. Let <a>domainLookupStart</a>,
 <a>domainLookupEnd</a>, <a>connectStart</a> and <a>connectEnd</a>
@@ -1068,8 +1068,8 @@ document</a></dfn>, abort the remaining steps.</li>
 user agent MUST set <a>redirectStart</a>, <a>redirectEnd</a>,
 <a>domainLookupStart</a>, <a>domainLookupEnd</a>, <a>connectStart</a>,
 <a>connectEnd</a>, <a>requestStart</a>, <a>responseStart</a> and
-<a>secureConnectionStart</a> to zero and go to step <a href=
-"#dfn-step-response-end">16</a>.</li>
+<a>secureConnectionStart</a> to zero and go to the step labeled <a href=
+"#dfn-step-response-end">response end</a>.</li>
 <li>Let <a>domainLookupStart</a>, <a>domainLookupEnd</a>,
 <a>connectStart</a> and <a>connectEnd</a> be the same value as
 <a>fetchStart</a>.</li>
@@ -1077,18 +1077,19 @@ user agent MUST set <a>redirectStart</a>, <a>redirectEnd</a>,
 "HTML#relevant-application-cache">relevant application cache</a> or
 local resources, including the <a href=
 "https://tools.ietf.org/html/rfc7234">HTTP cache</a> [[RFC7234]],
-go to step <a href="#dfn-step-request-start">14</a>.</li>
-<li>If no domain lookup is required, go to step <a href=
-"#dfn-step-connect-start">14</a>. Otherwise, immediately before a
-user agent starts the domain name lookup, record the time as
+go to the step labeled <a href="#dfn-step-request-start">request
+start</a>.</li>
+<li>If no domain lookup is required, go to the step labeled <a href=
+"#dfn-step-connect-start">connect start</a>. Otherwise, immediately
+before a user agent starts the domain name lookup, record the time as
 <a>domainLookupStart</a>.</li>
 <li>Record the time as <a>domainLookupEnd</a> immediately after the
 domain name lookup is successfully done. A user agent may need
 multiple retries before that. If the domain name lookup fails and
 resource passes the <a>timing allow check</a> record the time as
-<a>domainLookupEnd</a> and go to <a href=
-"#dfn-step-final-record">step 17</a>.</li>
-<li><dfn data-lt="step-connect-start">If a persistent transport
+<a>domainLookupEnd</a> and go to the step labeled<a href=
+"#dfn-step-final-record">final record</a>.</li>
+<li><em>Connect start:</em> <dfn data-lt="step-connect-start">If a persistent transport
 connection is used to <a data-cite="FETCH#concept-fetch">fetch</a>
 the resource</dfn>, let <a>connectStart</a> and <a>connectEnd</a>
 be the same value of <a>domainLookupEnd</a>. Otherwise, record the
@@ -1101,8 +1102,8 @@ successful connection only.
 Once connection is established set the value of <a>nextHopProtocol</a>
 to the ALPN ID used by the connection. If a connection can not be
 established, record the time up to the connection failure as
-<a>connectEnd</a> and go to <a href= "#dfn-step-final-record">step
-17</a>.</li>
+<a>connectEnd</a> and go to the step labeled <a
+href= "#dfn-step-final-record">final record</a>.</li>
 <li>The user agent MUST set the <a>secureConnectionStart</a>
 attribute as follows:
 <ol>
@@ -1113,8 +1114,9 @@ handshake process to secure the connection.</li>
 the value of <a>secureConnectionStart</a> to 0.</li>
 </ol>
 </li>
-<li><dfn data-lt="step-request-start">Immediately before a user
-agent starts sending the request for the resource</dfn>, record the
+<li><em>Request start:</em> <dfn
+data-lt="step-request-start">Immediately before a user agent starts
+sending the request for the resource</dfn>, record the
 <a>current time</a> as <a>requestStart</a>. If a user agent needed
 multiple retries to send the request, record the <a>current time</a>
 of the last attempt.</li>
@@ -1125,11 +1127,11 @@ to always be in a particular order. </p>
 <li>Record the time as <a>responseStart</a> <dfn data-lt=
 "step-response-start">immediately after the user agent receives the
 first byte of the response</dfn>.</li>
-<li>Record the time as <a>responseEnd</a> <dfn data-lt=
-"step-response-end">immediately after receiving the last byte of
+<li><em>Response end:</em> Record the time as <a>responseEnd</a> <dfn
+data-lt="step-response-end">immediately after receiving the last byte of
 the response</dfn>.
 <ol>
-<li>Return to step <a href="#dfn-step-connect-start">12</a> if the
+<li>Return to the step labeled <a href="#dfn-step-connect-start">connect start</a> if the
 user agent fails to send the request or receive the entire
 response, and needs to reopen the connection.
 <aside class="example">
@@ -1147,7 +1149,8 @@ collected over the re-open connection.</p>
 <a>timing allow check</a> algorithm.</li>
 </ol>
 </li>
-<li>If <a data-link-for="PerformanceResourceTiming">responseEnd</a>
+<li><em>Final record:</em> If <a
+data-link-for="PerformanceResourceTiming">responseEnd</a>
 is not set, set it to the current time. <dfn data-lt=
 "step-final-record">Record the difference between
 <a>responseEnd</a> and <a>startTime</a> in
@@ -1158,16 +1161,17 @@ is not set, set it to the current time. <dfn data-lt=
 <ol>
 <li>If the current resource fails the <a>timing allow check</a>
 algorithm, set <a>redirectStart</a> and <a>redirectEnd</a> to 0.
-Then, return to step <a href="#dfn-step-fetch-start">7</a> with the
-redirected resource.</li>
+Then, return to the step labeled <a
+href="#dfn-step-fetch-start">Fetch start</a> with the redirected
+resource.</li>
 <li>If the value of redirectStart is not set, let it be the value
 of fetchStart.</li>
 <li>Let redirectEnd be the value of responseEnd.</li>
 <li>Set all the attributes in the <a>PerformanceResourceTiming</a>
 object to 0 except <a>startTime</a>, <a>redirectStart</a>,
 <a>redirectEnd</a>, and <a>initiatorType</a>.</li>
-<li>Return to step <a href="#dfn-step-fetch-start">7</a> with the
-new resource.</li>
+<li>Return to the step labeled <a href="#dfn-step-fetch-start">Fetch
+start</a> with the redirected resource.</li>
 </ol>
 </li>
 <li><dfn data-lt="step-final-queue"><a data-cite=

--- a/index.html
+++ b/index.html
@@ -951,21 +951,20 @@ separated by a comma.</p>
 whether a resource's timing information can be shared with the
 <a>current document</a>, is as follows:</p>
 <ol>
-    <li><p>Let <var>tainted</var> be <code>false</code>.</p></li>
+    <li><p>Let <var>tainted</var> be false.</p></li>
     <li><p>For each request in the resource <a
     data-cite="FETCH#concept-fetch">fetch</a> redirection-chain:</p>
         <ol>
+            <li><p>If the request is <a>cross-origin</a>, set
+            <var>tainted</var> to true.</p></li>
             <li><p>If the <a>Timing-Allow-Origin</a> header value list
             does not contain a value which is byte-for-byte identical to
             the <a
             data-cite="HTML#ascii-serialisation-of-an-origin">serialization</a>
             of the <a>current document</a>'s <a
             data-cite="DOM#concept-document-origin">origin</a>, nor a
-            wildcard ("<code>*</code>"), and the request is
-            <a>cross-origin</a> or <var>tainted</var> is
-            <code>true</code>, return <code>fail</code>.</p></li>
-            <li><p>If the request is <a>cross-origin</a>, set
-            <var>tainted</var> to <code>true</code>.</p></li>
+            wildcard ("<code>*</code>"), and <var>tainted</var> is
+            true, return <code>fail</code>.</p></li>
         </ol>
     <li><p>Return pass.</p></li>
 </ol>

--- a/index.html
+++ b/index.html
@@ -376,9 +376,7 @@ This attribute MUST NOT change even if the <a data-cite=
 starts to queue the resource for <a data-cite="FETCH#concept-fetch"
 data-lt='fetch'>fetching</a>. If there are HTTP redirects or
 <a data-cite="HTML#or-equivalent">equivalent</a> when fetching the
-resource, and if all the redirects or equivalent are from the
-<a data-cite="RFC6454#section-5">same origin</a> as the current
-document or the <a>timing allow check</a> algorithm passes, this
+resource, and if the <a>timing allow check</a> algorithm passes, this
 attribute MUST return the same value as <a>redirectStart</a>.
 Otherwise, this attribute MUST return the same value as
 <a>fetchStart</a>.</dd>
@@ -506,8 +504,7 @@ initiates the redirect, if there are HTTP redirects or
 <a data-cite="HTML#or-equivalent" data-lt=
 'HTTP response codes equivalence'>equivalent</a> when <a data-cite=
 "FETCH#concept-fetch" data-lt='fetch'>fetching</a> the resource and
-<strong>all</strong> the redirects or equivalent pass the <a>timing
-allow check</a> algorithm.</li>
+the resource passes the <a>timing allow check</a> algorithm.</li>
 <li>zero, otherwise.</li>
 </ol>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
@@ -518,8 +515,7 @@ response of the last redirect, if there are HTTP redirects or
 <a data-cite="HTML#or-equivalent" data-lt=
 'HTTP response codes equivalence'>equivalent</a> when <a data-cite=
 "FETCH#concept-fetch" data-lt='fetch'>fetching</a> the resource and
-<strong>all</strong> the redirects or equivalent pass the <a>timing
-allow check</a> algorithm.</li>
+the resource passes the <a>timing allow check</a> algorithm.</li>
 <li>zero, otherwise.</li>
 </ol>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
@@ -537,9 +533,8 @@ otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any request in the resource <a
-data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
-redirects) fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if the resource fails the <a>timing allow check</a>
+algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if no domain lookup was
 required to fetch the resources (e.g. if a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
@@ -555,9 +550,8 @@ name lookup for the resource, otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>domainLookupEnd</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any request in the resource <a
-data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
-redirects) fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if the resource fails the <a>timing allow check</a>
+algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if no domain lookup was
 required to fetch the resources (e.g. if a <a href=
 "https://tools.ietf.org/html/RFC7230#section-6.3">persistent
@@ -573,9 +567,8 @@ name lookup for the resource, otherwise.</li>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>connectStart</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any request in the resource <a
-data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
-redirects) fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if the resource fails the <a>timing allow check</a>
+algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -593,9 +586,8 @@ corresponding value of the new connection.</p>
 <p data-dfn-for="PerformanceResourceTiming">On getting, the
 <dfn>connectEnd</dfn> attribute MUST return as follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if any request in the resource <a
-data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
-redirects) fails the <a>timing allow check</a> algorithm.</li>
+<li>Zero, if the resource fails the <a>timing allow check</a>
+algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -616,10 +608,8 @@ corresponding value of the new connection.</p>
 <dfn>secureConnectionStart</dfn> attribute MUST return as
 follows:</p>
 <ol data-link-for="PerformanceResourceTiming">
-<li>Zero, if a secure transport is not used or if any request in the
-resource <a data-cite="FETCH#concept-fetch">fetch</a>'s request-chain
-(including redirects) fails the <a>timing allow check</a> algorithm.
-</li>
+<li>Zero, if a secure transport is not used or if the resource fails
+the <a>timing allow check</a> algorithm.</li>
 <li>The same value as <a>fetchStart</a>, if a <a data-cite=
 "RFC7230#section-6.3">persistent connection</a> [[RFC7230]] is used
 or the resource is retrieved from <a data-cite=
@@ -634,9 +624,8 @@ process to secure the current connection, otherwise.</li>
 <li>The time immediately before the user agent starts requesting
 the resource from the server, or from <a data-cite=
 "HTML#relevant-application-cache">relevant application caches</a>
-or from local resources, if all requests in the resource <a data-cite=
-"FETCH#concept-fetch">fetch</a>'s request-chain (including redirects)
-pass the <a>timing allow check</a> algorithm.
+or from local resources, if the resource passes the <a>timing allow
+check</a> algorithm.
 <p>If the transport connection fails after a request is sent and
 the user agent reopens a connection and resend the request,
 <a data-link-for="PerformanceResourceTiming">requestStart</a> MUST
@@ -664,10 +653,8 @@ encapsulation.</li>
 receives the first byte of the response (e.g. frame header bytes
 for HTTP/2, or response status line for HTTP/1.x) from
 <a data-cite="HTML#relevant-application-cache">relevant application
-caches</a>, or from local resources or from the server if all
-requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
-request-chain (including redirects) pass the <a>timing allow check</a>
-algorithm.</li>
+caches</a>, or from local resources or from the server, if the
+resource passes the <a>timing allow check</a> algorithm.</li>
 <li>zero, otherwise.</li>
 </ol>
 <aside class="note">
@@ -703,10 +690,8 @@ to a network error.</li>
 <li>the size, in octets received from a <a data-cite=
 "FETCH#http-network-fetch">HTTP-network fetch</a>, consumed by the
 response header fields and the response <a data-cite=
-"RFC7230#section-3.3">payload body</a> [[RFC7230]] if all
-requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
-request-chain (including redirects) pass the <a>timing allow check</a>
-algorithm.
+"RFC7230#section-3.3">payload body</a> [[RFC7230]], if the
+resource passes the <a>timing allow check</a> algorithm.
 <p>If there are HTTP redirects or <a data-cite="HTML#or-equivalent"
 data-lt='HTTP response codes equivalence'>equivalent</a> when
 navigating and if all the redirects or equivalent are from the same
@@ -741,9 +726,8 @@ caches</a> or from local resources.</li>
 "FETCH#http-network-or-cache-fetch">HTTP-network-or-cache</a>
 fetch, of the <a data-cite="RFC7230#section-3.3">payload body</a>
 [[RFC7230]], prior to removing any applied <a data-cite=
-"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if all
-requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
-request-chain (including redirects) pass the <a>timing allow check</a> algorithm.</li>
+"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if the
+resource passes the <a>timing allow check</a> algorithm.</li>
 <li>The size, in octets, of the <a data-cite=
 "RFC7230#section-3.3">payload body</a> prior to removing any
 applied <a data-cite="RFC7231#section-3.1.2.1">content-codings</a>
@@ -764,9 +748,8 @@ etc.</aside>
 "FETCH#http-network-or-cache-fetch">HTTP-network-or-cache</a>
 fetch, of the <a data-cite="RFC7230#section-3.3">message body</a>
 [[RFC7230]], after removing any applied <a data-cite=
-"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if all
-requests in the resource <a data-cite= "FETCH#concept-fetch">fetch</a>'s
-request-chain (including redirects) pass the <a>timing allow check</a> algorithm.</li>
+"RFC7231#section-3.1.2.1">content-codings</a> [[RFC7231]], if the
+resource passes the <a>timing allow check</a> algorithm.</li>
 <li>The size, in octets, of the <a data-cite=
 "RFC7230#section-3.3">payload</a> after removing any applied
 <a data-cite="RFC7231#section-3.1.2.1">content-codings</a>, if the
@@ -933,8 +916,8 @@ MUST be included as <a>PerformanceResourceTiming</a> objects in the
 <a data-cite=
 "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
 Timeline</a>. If the <a>timing allow check</a> algorithm fails for
-a <a>cross-origin</a> resource, these attributes of its
-<a>PerformanceResourceTiming</a> object MUST be set to zero:
+a resource, these attributes of its <a>PerformanceResourceTiming</a>
+object MUST be set to zero:
 <a>redirectStart</a>, <a>redirectEnd</a>, <a>domainLookupStart</a>,
 <a>domainLookupEnd</a>, <a>connectStart</a>, <a>connectEnd</a>,
 <a>requestStart</a>, <a>responseStart</a>,
@@ -968,17 +951,23 @@ separated by a comma.</p>
 whether a resource's timing information can be shared with the
 <a>current document</a>, is as follows:</p>
 <ol>
-<li>
-<p>If the resource is same origin, return <code>pass</code>.</p>
-</li>
-<li>
-<p>If the <a>Timing-Allow-Origin</a> header value list contains a
-case-sensitive match for the value of the <code><a data-cite=
-"RFC6454#section-4" data-lt="http-origin">origin</a></code> of the
-<a>current document</a>, or a wildcard ("<code>*</code>"), return
-<code>pass</code>.</p>
-</li>
-<li>Return <code>fail</code>.</li>
+    <li><p>Let <var>tainted</var> be <code>false</code>.</p></li>
+    <li><p>For each request in the resource <a
+    data-cite="FETCH#concept-fetch">fetch</a> redirection-chain:</p>
+        <ol>
+            <li><p>If the <a>Timing-Allow-Origin</a> header value list
+            does not contain a value which is byte-for-byte identical to
+             the <a
+            data-cite="HTML#ascii-serialisation-of-an-origin">serialization</a>
+            of the <a>current document</a>'s <a
+            data-cite="DOM#concept-document-origin">origin</a>, nor a
+            wildcard ("<code>*</code>"), and the request is
+            <a>cross-origin</a> or <var>tainted</var> is
+            <code>true</code>, return <code>fail</code>.</p></li>
+            <li><p>If the request is <a>cross-origin</a>, set
+                <var>tainted</var> to <code>true</code>.</p></li>
+        </ol>
+    <li><p>Return pass.</p></li>
 </ol>
 </section>
 <section id="sec-iana-considerations">
@@ -1008,7 +997,7 @@ intervals between timings.</p>
 <figcaption>This figure illustrates the timing attributes defined
 by the <a>PerformanceResourceTiming</a> interface. Attributes in
 parenthesis indicate that they may not be available if the resource
-does not pass the <a>timing allow check</a> algorithm.</figcaption>
+fails the <a>timing allow check</a> algorithm.</figcaption>
 <!-- Source: https://docs.google.com/document/d/1I7XGNJ57Qgjkg9pL11s7MK7zGEcwAgdNj1W5f7NKbW8/ -->
 <img src="timestamp-diagram.svg" alt="Resource Timing attributes"
 style='margin-top: 1em'></figure>
@@ -1066,10 +1055,8 @@ be the same value as <a>fetchStart</a>.</li>
 reuse the data from another existing or completed <a data-cite=
 "FETCH#concept-fetch">fetch</a> initiated from the <a>current
 document</a></dfn>, abort the remaining steps.</li>
-<li>If any request in the resource <a
-data-cite="FETCH#concept-fetch">fetch</a>'s request-chain (including
-redirects) fails the <a>timing allow check</a> algorithm, the user
-agent MUST set <a>redirectStart</a>, <a>redirectEnd</a>,
+<li>If the resource fails the <a>timing allow check</a> algorithm, the
+user agent MUST set <a>redirectStart</a>, <a>redirectEnd</a>,
 <a>domainLookupStart</a>, <a>domainLookupEnd</a>, <a>connectStart</a>,
 <a>connectEnd</a>, <a>requestStart</a>, <a>responseStart</a> and
 <a>secureConnectionStart</a> to zero and go to step <a href=

--- a/index.html
+++ b/index.html
@@ -965,7 +965,7 @@ whether a resource's timing information can be shared with the
             <a>cross-origin</a> or <var>tainted</var> is
             <code>true</code>, return <code>fail</code>.</p></li>
             <li><p>If the request is <a>cross-origin</a>, set
-                <var>tainted</var> to <code>true</code>.</p></li>
+            <var>tainted</var> to <code>true</code>.</p></li>
         </ol>
     <li><p>Return pass.</p></li>
 </ol>

--- a/index.html
+++ b/index.html
@@ -957,7 +957,7 @@ whether a resource's timing information can be shared with the
         <ol>
             <li><p>If the <a>Timing-Allow-Origin</a> header value list
             does not contain a value which is byte-for-byte identical to
-             the <a
+            the <a
             data-cite="HTML#ascii-serialisation-of-an-origin">serialization</a>
             of the <a>current document</a>'s <a
             data-cite="DOM#concept-document-origin">origin</a>, nor a


### PR DESCRIPTION
Supersedes https://github.com/w3c/resource-timing/pull/172 and improves on https://github.com/w3c/resource-timing/pull/196 by aligning with the CORS model, even if in a handwavy way for now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/197.html" title="Last updated on Feb 11, 2019, 7:22 PM UTC (db31e5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/197/9b75d42...yoavweiss:db31e5a.html" title="Last updated on Feb 11, 2019, 7:22 PM UTC (db31e5a)">Diff</a>