### PR TITLE
Use FETCH#URL to describe the name of a request

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,9 +365,9 @@ interface:</p>
 <dl data-link-for="PerformanceResourceTiming">
 <dt><dfn>name</dfn></dt>
 <dd>This attribute MUST return the <a data-cite=
-"HTML#resolve-a-url">resolved URL</a> of the requested resource.
-This attribute MUST NOT change even if the <a data-cite=
-"FETCH#concept-fetch">fetch</a> redirected to a different URL.</dd>
+"FETCH#concept-request-url">URL</a> of the resource's <a data-cite=
+"FETCH#concept-request">request</a>.
+<p class="note">This is the URL requested originally, and is not affected by redirects.</dd>
 <dt><dfn>entryType</dfn></dt>
 <dd>The <a>entryType</a> attribute MUST return the DOMString
 "<code>resource</code>".</dd>


### PR DESCRIPTION
Instead of specifying here that it's the URL before redirects,
which is essentially the same thing.

Closes https://github.com/w3c/resource-timing/issues/244


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/257.html" title="Last updated on Feb 28, 2021, 11:28 AM UTC (f3f4bf0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/257/05e9c1b...f3f4bf0.html" title="Last updated on Feb 28, 2021, 11:28 AM UTC (f3f4bf0)">Diff</a>