### PR TITLE
Remove unused 'current time' definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,11 +251,6 @@
         "NAVIGATION-TIMING-2#dom-PerformanceNavigationTiming-startTime">start
         of navigation of the document</a> occurs at time 0.
       </p>
-      <p>
-        The term <dfn>current time</dfn> refers to the number of milliseconds
-        since the start of navigation of the document until the current moment
-        in time.
-      </p>
       <p class='note'>
         This definition of time is based on the High Resolution Time
         specification [[HR-TIME-2]] and is different from the definition of


### PR DESCRIPTION
Closes #235


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/295.html" title="Last updated on Sep 29, 2021, 1:03 PM UTC (d86b900)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/295/35a3ec0...d86b900.html" title="Last updated on Sep 29, 2021, 1:03 PM UTC (d86b900)">Diff</a>