### PR TITLE
Fix a link to the HR-TIME spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1133,9 +1133,9 @@
         <ol>
           <li>If |ts| is zero, return zero.
           </li>
-          <li>Otherwise, return the <a data-cite=
-          "HR-TIME#dfn-relative-high-resolution-coarse-time">relative high
-          resolution coarse time</a> given |ts| and |global|.
+          <li>
+            Otherwise, return the [=relative high resolution coarse time=]
+            given |ts| and |global|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     github: "https://github.com/w3c/resource-timing/",
     caniuse: "resource-timing",
     xref: {
-      specs: ["hr-time-3", "performance-timeline-2", "xhr"],
+      specs: ["hr-time-3", "performance-timeline", "performance-timeline-2", "xhr"],
       profile: "web-platform",
     }
     };

--- a/index.html
+++ b/index.html
@@ -1134,7 +1134,7 @@
           <li>If |ts| is zero, return zero.
           </li>
           <li>Otherwise, return the <a data-cite=
-          "HR-TIME#relative-high-resolution-coarse-time">relative high
+          "HR-TIME#dfn-relative-high-resolution-coarse-time">relative high
           resolution coarse time</a> given |ts| and |global|.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     github: "https://github.com/w3c/resource-timing/",
     caniuse: "resource-timing",
     xref: {
-      specs: ["hr-time-3", "performance-timeline", "performance-timeline-2", "xhr"],
+      specs: ["hr-time-3", "performance-timeline", "xhr"],
       profile: "web-platform",
     }
     };


### PR DESCRIPTION
The current link goes to the HR-TIME spec but the URL fragment was missing a prefix so it didn't auto-scroll to the targeted definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tommckee1/resource-timing/pull/308.html" title="Last updated on Jan 10, 2022, 5:43 PM UTC (64e53b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/308/1d747a0...tommckee1:64e53b2.html" title="Last updated on Jan 10, 2022, 5:43 PM UTC (64e53b2)">Diff</a>