### PR TITLE
Clean up unused definitions and other respec errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,8 +480,9 @@
             </li>
             <li>
               <code>"css"</code>, if the request is a result of processing a CSS
-              <a data-cite="css-values-4#funcdef-url">url()</a> directive such
-              as <code>@import url()</code> or <code>background: url()</code>;
+              <a data-cite="css-values-4"
+              data-xref-type="css-function">url()</a> directive such as
+              <code>@import url()</code> or <code>background: url()</code>;
               [[CSS-VALUES]]
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -213,9 +213,6 @@
         "an object implementing the interface <code>Foo</code>.
       </p>
       <p>
-        The term <dfn>cross-origin</dfn> is used to mean non [=same origin=].
-      </p>
-      <p>
         Throughout this work, all time values are measured in milliseconds
         since the start of navigation of the document [[HR-TIME-2]]. For
         example, the <a data-cite=
@@ -939,8 +936,7 @@
           Server-side applications may return the <a>Timing-Allow-Origin</a>
           HTTP response header to allow the User Agent to fully expose, to the
           document origin(s) specified, the values of attributes that would
-          have been zero due to the <a>cross-origin</a> restrictions previously
-          specified in this section.
+          have been zero due to those cross-origin restrictions.
         </p>
         <section id="sec-timing-allow-origin">
           <h4>
@@ -1029,7 +1025,7 @@
         <p>
           The following graph illustrates the timing attributes defined by the
           PerformanceResourceTiming interface. Attributes in parenthesis may
-          not be available when [=fetch|fetching=] <a>cross-origin</a>
+          not be available when [=fetch|fetching=] cross-origin
           resources. User agents may perform internal processing in between
           timings, which allow for non-normative intervals between timings.
         </p>

--- a/index.html
+++ b/index.html
@@ -64,7 +64,10 @@
     subjectPrefix: "[ResourceTiming]",
     github: "https://github.com/w3c/resource-timing/",
     caniuse: "resource-timing",
-    xref: ["html", "hr-time-3", "performance-timeline-2", "fetch", "infra"],
+    xref: {
+      specs: ["hr-time-3", "performance-timeline-2", "xhr"],
+      profile: "web-platform",
+    }
     };
     </script>
   </head>
@@ -212,8 +215,8 @@
       <p>
         The term <dfn>DOM</dfn> is used to refer to the API set made available
         to scripts in Web applications, and does not necessarily imply the
-        existence of an actual <a data-cite="DOM#document">Document</a> object
-        or of any other <a data-cite="DOM#node">Node</a> objects as defined in
+        existence of an actual [=Document=]</a> object
+        or of any other [=Node=]</a> objects as defined in
         the [[DOM]] specification.
       </p>
       <p>
@@ -235,8 +238,7 @@
         svg.
       </p>
       <p>
-        The term <dfn>cross-origin</dfn> is used to mean non <a data-cite=
-        "HTML#same-origin">same origin</a>.
+        The term <dfn>cross-origin</dfn> is used to mean non [=same origin=]</a>.
       </p>
       <p>
         The term <dfn>current document</dfn> refers to the document associated
@@ -271,20 +273,14 @@
         <h3>
           Introduction
         </h3>
-        <p>
+        <p data-fn-for="html">
           The <a>PerformanceResourceTiming</a> interface facilitates timing
           measurement of downloadable resources. For example, this interface is
-          available for <a data-cite=
-          "XHR#interface-xmlhttprequest">XMLHttpRequest</a> objects [[XHR]],
-          HTML elements [[HTML]] such as <a data-cite=
-          "HTML#the-iframe-element">iframe</a>, <a data-cite=
-          "HTML#the-img-element">img</a>, <a data-cite=
-          "HTML#the-script-element">script</a>, <a data-cite=
-          "HTML#the-object-element">object</a>, <a data-cite=
-          "HTML#the-embed-element">embed</a>, and <a data-cite=
-          "HTML#the-link-element">link</a> with the link type of <a data-cite=
-          "HTML#link-type-stylesheet">stylesheet</a>, and SVG elements
-          [[SVG11]] such as <a data-cite=
+          available for {{XMLHttpRequest}} objects [[XHR]],
+          HTML elements [[HTML]] such as [^iframe^], [^img^],
+          [^script^], [^object^], [^embed^]
+          and [^link^] with the link type of [^link/rel/stylesheet^], 
+          and SVG elements [[SVG11]] such as <a data-cite=
           "SVG11/struct.html#SVGElement">svg</a>.
         </p>
       </section>
@@ -293,12 +289,11 @@
           Resources Included in the <a>PerformanceResourceTiming</a> Interface
         </h3>
         <p>
-          All resource <dfn data-cite="Fetch#concept-request">Request</dfn>s
-          <a data-cite="FETCH#concept-fetch">fetched</a> by a non-null
-          <dfn data-cite="Fetch#concept-request-client">client</dfn> MUST be
+          All resource [=Request=]s
+          [=fetch=]ed</a> by a non-null
+          [=request/client=] MUST be
           included as <a>PerformanceResourceTiming</a> objects in the
-          <a>client</a>'s <dfn data-cite=
-          "HTML#concept-settings-object-global">global object</dfn>'s
+          [=request/client=]'s [=environment settings object/global object=]'s
           <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
           Timeline</a>, unless excluded from the timeline as part of the
@@ -308,7 +303,7 @@
           <a>PerformanceResourceTiming</a> objects in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
           Timeline</a> [[PERFORMANCE-TIMELINE-2]]. Resources for which the
-          <a data-cite="FETCH#concept-fetch">fetch</a> was initiated, but was
+          [=fetch=] was initiated, but was
           later aborted (e.g. due to a network error) MAY be included as
           <a>PerformanceResourceTiming</a> objects in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
@@ -331,7 +326,7 @@
           Timeline</a>. The user agent might not re-request the URL for the
           second HTML <code>IMG</code> element, instead using the existing
           download it initiated for the first HTML <code>IMG</code> element. In
-          this case, the <a data-cite="FETCH#concept-fetch">fetch</a> of the
+          this case, the [=fetch=] of the
           resource by the first <code>IMG</code> element would be the only
           occurrence in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
@@ -339,7 +334,7 @@
           </li>
           <li>If the <code>src</code> attribute of a HTML <code>IMG</code>
           element is changed via script, both the [=fetch=] of the original
-          resource as well as the <a data-cite="FETCH#concept-fetch">fetch</a>
+          resource as well as the [=fetch=]</a>
           of the new URL would be included as <a>PerformanceResourceTiming</a>
           objects in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
@@ -350,7 +345,7 @@
           load the <code>about:blank</code> document for the
           <code>IFRAME</code>. If at a later time the <code>src</code>
           attribute is changed dynamically via script, the user agent may
-          <a data-cite="FETCH#concept-fetch">fetch</a> the new URL resource for
+          [=fetch=] the new URL resource for
           the <code>IFRAME</code>. In this case, only the [=fetch=] of the new
           URL would be included as a <a>PerformanceResourceTiming</a> object in
           the <a data-cite=
@@ -358,7 +353,7 @@
           Timeline</a>.
           </li>
           <li>If an <code>XMLHttpRequest</code> is generated twice for the same
-          canonical URL, both <a data-cite="FETCH#concept-fetch">fetches</a> of
+          canonical URL, both [=fetches=]</a> of
           the resource would be included as a <a>PerformanceResourceTiming</a>
           object in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
@@ -664,8 +659,7 @@
         </ol>
         <p class='note'>
           A user agent implementing <a>PerformanceResourceTiming</a> would need
-          to include <code>"resource"</code> in <a data-cite=
-          "PERFORMANCE-TIMELINE-2#supportedentrytypes-attribute">supportedEntryTypes</a>.
+          to include <code>"resource"</code> in {{PerformanceObserver/supportedEntryTypes}}.
           This allows developers to detect support for Resource Timing.
         </p>
       </section>
@@ -845,9 +839,8 @@
               timing secondary buffer current size</a>.
               </li>
               <li>If <a>can add resource timing entry</a> returns false, then
-              <a data-cite="DOM/#concept-event-fire">fire an event</a> named
-              <code>resourcetimingbufferfull</code> at the <a data-cite=
-              "HR-TIME-2/#idl-def-performance">Performance</a> object.
+              [=fire an event=]</a> named
+              <code>resourcetimingbufferfull</code> at the {{Performance}} object.
               </li>
               <li>Run <a>copy secondary buffer</a>.
               </li>

--- a/index.html
+++ b/index.html
@@ -213,36 +213,7 @@
         "an object implementing the interface <code>Foo</code>.
       </p>
       <p>
-        The term <dfn>DOM</dfn> is used to refer to the API set made available
-        to scripts in Web applications, and does not necessarily imply the
-        existence of an actual [=Document=] object or of any other [=Node=]
-        objects as defined in the [[DOM]] specification.
-      </p>
-      <p>
-        A DOM attribute is said to be <dfn>getting</dfn> when its value is
-        being retrieved (such as by author script), and is said to be
-        <dfn>setting</dfn> when a new value is assigned to it.
-      </p>
-      <p>
-        The term <dfn>JavaScript</dfn> is used to refer to ECMA262, rather than
-        the official term ECMAScript, since the term JavaScript is more widely
-        known. [[ECMASCRIPT]]
-      </p>
-      <p>
-        The term <dfn>resource</dfn> is used to refer to elements and any other
-        user-initiated fetches throughout this specification. For example, a
-        resource could originate from XMLHttpRequest objects [[XHR]], HTML
-        elements [[HTML]] such as iframe, img, script, object, embed, and link
-        with the link type of stylesheet, and SVG elements [[SVG11]] such as
-        svg.
-      </p>
-      <p>
         The term <dfn>cross-origin</dfn> is used to mean non [=same origin=].
-      </p>
-      <p>
-        The term <dfn>current document</dfn> refers to the document associated
-        with the <a data-cite="HTML#concept-document-window">Window object's
-        newest Document object</a>.
       </p>
       <p>
         Throughout this work, all time values are measured in milliseconds
@@ -504,71 +475,71 @@
           </p>
           <ul>
             <li>
-              <dfn>"navigation"</dfn>, if the request is a [=navigation
+              <code>"navigation"</code>, if the request is a [=navigation
               request=];
             </li>
             <li>
-              <dfn>"css"</dfn>, if the request is a result of processing a CSS
-              <a data-xref-type="css-function">url()</a> directive such as
-              <code>@import url()</code> or <code>background: url()</code>;
+              <code>"css"</code>, if the request is a result of processing a CSS
+              <a data-cite="css-values-4#funcdef-url">url()</a> directive such
+              as <code>@import url()</code> or <code>background: url()</code>;
               [[CSS-VALUES]]
             </li>
             <li>
-              <dfn>"script"</dfn>, if the request is a result of loading any
+              <code>"script"</code>, if the request is a result of loading any
               <a data-cite="HTML#concept-script">script</a> (a classic
               [^script^], a [=module script=], or a {{Worker}}).
             </li>
             <li>
-              <dfn>"xmlhttprequest"</dfn>, if the request is a result of
+              <code>"xmlhttprequest"</code>, if the request is a result of
               processing an {{XMLHttpRequest}};
             </li>
             <li>
-              <dfn>"fetch"</dfn>, if the request is the result of processing
+              <code>"fetch"</code>, if the request is the result of processing
               the {{WindowOrWorkerGlobalScope/fetch()}} method;
             </li>
             <li>
-              <dfn>"beacon"</dfn>, if the request is the result of processing
+              <code>"beacon"</code>, if the request is the result of processing
               the {{Navigator/sendBeacon()}} method; [[BEACON]]
             </li>
             <li>
-              <dfn>"video"</dfn>, if the request is the result of processing
+              <code>"video"</code>, if the request is the result of processing
               the [^video^] element's [^video/poster^] or [^video/src^].
             </li>
             <li>
-              <dfn>"audio"</dfn>, if the request is the result of processing
+              <code>"audio"</code>, if the request is the result of processing
               the [^audio^] element's [^audio/src^].
             </li>
             <li>
-              <dfn>"track"</dfn>, if the request is the result of processing
+              <code>"track"</code>, if the request is the result of processing
               the [^track^] element's [^track/src^].
             </li>
             <li>
-              <dfn>"img"</dfn>, if the request is the result of processing the
+              <code>"img"</code>, if the request is the result of processing the
               [^img^] element's [^img/src^] or [^img/srcset^].
             </li>
             <li>
-              <dfn>"image"</dfn>, if the request is the result of processing
+              <code>"image"</code>, if the request is the result of processing
               the <a data-cite="SVG2/embedded.html#ImageElement">image</a>
               element. [[SVG2]]
             </li>
             <li>
-              <dfn>"input"</dfn>, if the request is the result of processing an
+              <code>"input"</code>, if the request is the result of processing an
               [^input^] element of [^input/type^] [^input/type/image^].
             </li>
             <li>
-              <dfn>"a"</dfn>, if the request is the result of processing an
+              <code>"a"</code>, if the request is the result of processing an
               [^a^] element's [^a/download^] or [^a/ping^].
             </li>
             <li>
-              <dfn>"iframe"</dfn>, if the request is the result of processing
+              <code>"iframe"</code>, if the request is the result of processing
               an [^iframe^]'s [^iframe/src^].
             </li>
             <li>
-              <dfn>"frame"</dfn>, if the request is the result of loading a
+              <code>"frame"</code>, if the request is the result of loading a
               [^frame^].
             </li>
             <li>
-              <dfn>"other"</dfn>, if none of the above conditions match.
+              <code>"other"</code>, if none of the above conditions match.
             </li>
           </ul>
         </div>
@@ -811,7 +782,7 @@
         </ol>
         <p>
           The attribute <dfn>onresourcetimingbufferfull</dfn> is the event
-          handler for the <dfn>resourcetimingbufferfull</dfn> event described
+          handler for the <code>resourcetimingbufferfull</code> event described
           below.
         </p>
         <p>
@@ -1097,7 +1068,7 @@
             "PERFORMANCE-TIMELINE-2#dfn-queue-a-performanceentry">Queue</a>
             |entry|.
           </li>
-          <li>Add |entry| to |global|'s <a data-cite=
+          <li>[=Add a PerformanceResourceTiming entry|Add=] |entry| to |global|'s <a data-cite=
           "PERFORMANCE-TIMELINE-2#dfn-performance-entry-buffer">performance
           entry buffer</a>.
           </li>
@@ -1139,9 +1110,9 @@
           </li>
         </ol>
       </section>
-      <section id="sec-privacy-security" class='informative'>
+      <section id="sec-security" class='informative'>
         <h2>
-          Privacy and Security
+          Security Considerations
         </h2>
         <p>
           The <a>PerformanceResourceTiming</a> interface exposes timing
@@ -1155,13 +1126,17 @@
           HTTP response header, which specifies the domains that are allowed to
           access the timing information.
         </p>
+      <section id="sec-privacy" class='informative'>
+        <h2>
+          Privacy Considerations
+        </h2>
         <p>
           Statistical fingerprinting is a privacy concern where a malicious web
           site may determine whether a user has visited a third-party web site
           by measuring the timing of cache hits and misses of resources in the
           third-party web site. Though the <a>PerformanceResourceTiming</a>
           interface gives timing information for resources in a document, the
-          cross-origin restrictions in in [=/HTTP Fetch=] prevent making this
+          cross-origin restrictions in [=/HTTP Fetch=] prevent making this
           privacy concern any worse than it is today using the load event on
           resources to measure timing to determine cache hits and misses.
         </p>

--- a/index.html
+++ b/index.html
@@ -215,8 +215,8 @@
       <p>
         The term <dfn>DOM</dfn> is used to refer to the API set made available
         to scripts in Web applications, and does not necessarily imply the
-        existence of an actual [=Document=]</a> object
-        or of any other [=Node=]</a> objects as defined in
+        existence of an actual [=Document=] object
+        or of any other [=Node=] objects as defined in
         the [[DOM]] specification.
       </p>
       <p>
@@ -238,7 +238,7 @@
         svg.
       </p>
       <p>
-        The term <dfn>cross-origin</dfn> is used to mean non [=same origin=]</a>.
+        The term <dfn>cross-origin</dfn> is used to mean non [=same origin=].
       </p>
       <p>
         The term <dfn>current document</dfn> refers to the document associated
@@ -290,7 +290,7 @@
         </h3>
         <p>
           All resource [=Request=]s
-          [=fetch=]ed</a> by a non-null
+          [=fetch=]ed by a non-null
           [=request/client=] MUST be
           included as <a>PerformanceResourceTiming</a> objects in the
           [=request/client=]'s [=environment settings object/global object=]'s
@@ -334,7 +334,7 @@
           </li>
           <li>If the <code>src</code> attribute of a HTML <code>IMG</code>
           element is changed via script, both the [=fetch=] of the original
-          resource as well as the [=fetch=]</a>
+          resource as well as the [=fetch=]
           of the new URL would be included as <a>PerformanceResourceTiming</a>
           objects in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
@@ -353,7 +353,7 @@
           Timeline</a>.
           </li>
           <li>If an <code>XMLHttpRequest</code> is generated twice for the same
-          canonical URL, both [=fetches=]</a> of
+          canonical URL, both [=fetches=] of
           the resource would be included as a <a>PerformanceResourceTiming</a>
           object in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
@@ -839,7 +839,7 @@
               timing secondary buffer current size</a>.
               </li>
               <li>If <a>can add resource timing entry</a> returns false, then
-              [=fire an event=]</a> named
+              [=fire an event=] named
               <code>resourcetimingbufferfull</code> at the {{Performance}} object.
               </li>
               <li>Run <a>copy secondary buffer</a>.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/resource-timing/pull/310.html" title="Last updated on Jan 12, 2022, 4:05 AM UTC (2367c71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/310/c6ad017...yoavweiss:2367c71.html" title="Last updated on Jan 12, 2022, 4:05 AM UTC (2367c71)">Diff</a>