### PR TITLE
List all the attributes that will get masked when TAO fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -944,14 +944,18 @@
           Cross-origin Resources
         </h3>
         <p class="note" data-dfn-for="PerformanceResourceTiming">
-          As detailed in [=Fetch=], cross-origin resources are included as
-          <a>PerformanceResourceTiming</a> objects in the <a data-cite=
-          "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
-          Timeline</a>. If the <a data-cite="FETCH#concept-tao-check">timing
-          allow check</a> algorithm fails for a resource, the corresponding
-          <a>PerformanceResourceTiming</a> object will have any attributes
-          exposing cross-origin data masked. Therfore, the following attributes
-          will be set to zero: {{PerformanceResourceTiming/redirectStart}},
+          As detailed in [=Fetch=], requests for cross-origin resources are
+          included as <a>PerformanceResourceTiming</a> objects in the
+          <a data-cite= "PERFORMANCE-TIMELINE-2#performance-timeline">
+          Performance Timeline</a>. If the <a
+          data-cite="FETCH#concept-tao-check">timing allow check</a> algorithm
+          fails for a cross-origin resource, the entry will be an
+          <a data-cite="FETCH#create-an-opaque-timing-info">opaque entry</a>.
+          Such entries have most of their attributes masked in order to prevent
+          leaking cross-origin data that isn't otherwise exposed. So, for an
+          <a data-cite="FETCH#create-an-opaque-timing-info">opaque entry</a>,
+          the following attributes will be set to zero:
+          {{PerformanceResourceTiming/redirectStart}},
           {{PerformanceResourceTiming/redirectEnd}},
           {{PerformanceResourceTiming/workerStart}},
           {{PerformanceResourceTiming/domainLookupStart}},

--- a/index.html
+++ b/index.html
@@ -948,10 +948,12 @@
           <a>PerformanceResourceTiming</a> objects in the <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
           Timeline</a>. If the <a data-cite="FETCH#concept-tao-check">timing
-          allow check</a> algorithm fails for a resource, the following
-          attributes of its <a>PerformanceResourceTiming</a> object are set to
+          allow check</a> algorithm fails for a resource, the corresponding
+          <a>PerformanceResourceTiming</a> object will have any sensitive
+          fields masked. Therfore, the following attributes will be set to
           zero: {{PerformanceResourceTiming/redirectStart}},
           {{PerformanceResourceTiming/redirectEnd}},
+          {{PerformanceResourceTiming/workerStart}},
           {{PerformanceResourceTiming/domainLookupStart}},
           {{PerformanceResourceTiming/domainLookupEnd}},
           {{PerformanceResourceTiming/connectStart}},
@@ -962,6 +964,8 @@
           {{PerformanceResourceTiming/transferSize}},
           {{PerformanceResourceTiming/encodedBodySize}}, and
           {{PerformanceResourceTiming/decodedBodySize}}.
+          Further, the {{PerformanceResourceTiming/nextHopProtocol} attribute
+          will be set to the empty string.
         </p>
         <p>
           Server-side applications may return the <a>Timing-Allow-Origin</a>

--- a/index.html
+++ b/index.html
@@ -947,14 +947,14 @@
           As detailed in [=Fetch=], requests for cross-origin resources are
           included as <a>PerformanceResourceTiming</a> objects in the
           <a data-cite= "PERFORMANCE-TIMELINE-2#performance-timeline">
-          Performance Timeline</a>. If the <a
-          data-cite="FETCH#concept-tao-check">timing allow check</a> algorithm
-          fails for a cross-origin resource, the entry will be an
-          <a data-cite="FETCH#create-an-opaque-timing-info">opaque entry</a>.
-          Such entries have most of their attributes masked in order to prevent
-          leaking cross-origin data that isn't otherwise exposed. So, for an
-          <a data-cite="FETCH#create-an-opaque-timing-info">opaque entry</a>,
-          the following attributes will be set to zero:
+          Performance Timeline</a>. If the
+          <a data-cite="FETCH#concept-tao-check">timing allow check</a>
+          algorithm fails for a cross-origin resource, the entry will be an
+          [=create an opaque timing info|opaque entry=]. Such entries have most
+          of their attributes masked in order to prevent leaking cross-origin
+          data that isn't otherwise exposed. So, for an
+          [=create an opaque timing info|opaque entry=], the following
+          attributes will be set to zero:
           {{PerformanceResourceTiming/redirectStart}},
           {{PerformanceResourceTiming/redirectEnd}},
           {{PerformanceResourceTiming/workerStart}},

--- a/index.html
+++ b/index.html
@@ -949,9 +949,9 @@
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
           Timeline</a>. If the <a data-cite="FETCH#concept-tao-check">timing
           allow check</a> algorithm fails for a resource, the corresponding
-          <a>PerformanceResourceTiming</a> object will have any sensitive
-          fields masked. Therfore, the following attributes will be set to
-          zero: {{PerformanceResourceTiming/redirectStart}},
+          <a>PerformanceResourceTiming</a> object will have any attributes
+          exposing cross-origin data masked. Therfore, the following attributes
+          will be set to zero: {{PerformanceResourceTiming/redirectStart}},
           {{PerformanceResourceTiming/redirectEnd}},
           {{PerformanceResourceTiming/workerStart}},
           {{PerformanceResourceTiming/domainLookupStart}},


### PR DESCRIPTION
Although the 'note' is non-normative, it's helpful for folks to see a more comprehensive list, IMO.

LMKWYT!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tommckee1/resource-timing/pull/311.html" title="Last updated on Jan 13, 2022, 2:36 PM UTC (4219593)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/311/dc1f469...tommckee1:4219593.html" title="Last updated on Jan 13, 2022, 2:36 PM UTC (4219593)">Diff</a>