### PR TITLE
Editorial: Remove 'relevant application caches'

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,10 +260,8 @@
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
           Timeline</a>, unless excluded from the timeline as part of the
           [=fetch|fetching process=]. Resources that are retrieved from
-          <a data-cite="HTML#relevant-application-cache">relevant application
-          caches</a> or local resources are included as
-          <a>PerformanceResourceTiming</a> objects in the <a data-cite=
-          "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
+          HTTP cache are included as <a>PerformanceResourceTiming</a> objects in the
+          <a data-cite="PERFORMANCE-TIMELINE-2#performance-timeline">Performance
           Timeline</a>. Resources for which the [=fetch=] was initiated, but
           was later aborted (e.g. due to a network error) are included as
           <a>PerformanceResourceTiming</a> objects in the <a data-cite=


### PR DESCRIPTION
Closes https://github.com/w3c/resource-timing/issues/317


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/318.html" title="Last updated on Jan 25, 2022, 5:15 PM UTC (6e4cbad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/318/b5d09c9...6e4cbad.html" title="Last updated on Jan 25, 2022, 5:15 PM UTC (6e4cbad)">Diff</a>