### PR TITLE
Use `response body info` instead of `timing info` for body sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1102,7 +1102,7 @@
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">timing
           info</a> to |timingInfo|.
-          <li>Set |entry|'s <a data-for="PerformanceResourceTiming">reponse body info</a>
+          <li>Set |entry|'s <a data-for="PerformanceResourceTiming">response body info</a>
           to |bodyInfo|.
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">cache

--- a/index.html
+++ b/index.html
@@ -405,7 +405,7 @@
           info</dfn></a>.
         </p>
         <p>
-          A <a>PerformanceResourceTiming</a> has an associated [=fetch resource
+          A <a>PerformanceResourceTiming</a> has an associated [=response body
           info=] <a data-dfn-for="PerformanceResourceTiming"><dfn>resource
           info</dfn></a>.
         </p>
@@ -686,7 +686,7 @@
           <li>
             <p>
               Return <a>this</a>'s <a data-for=
-              "PerformanceResourceTiming">response body info</a>'s [=fetch resource
+              "PerformanceResourceTiming">response body info</a>'s [=response body
               info/encoded body size=] plus 300.
             </p>
             <p class='note'>

--- a/index.html
+++ b/index.html
@@ -659,12 +659,12 @@
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>encodedBodySize</dfn> getter steps are to return
           <a>this</a>'s <a data-for="PerformanceResourceTiming">resource
-          info</a>'s [=response body info/encoded body size=].
+          info</a>'s [=response body info/encoded size=].
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>decodedBodySize</dfn> getter steps are to return
           <a>this</a>'s <a data-for="PerformanceResourceTiming">resource
-          info</a>'s [=response body info/decoded body size=].
+          info</a>'s [=response body info/decoded size=].
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>transferSize</dfn> getter steps are to perform the following
@@ -687,7 +687,7 @@
             <p>
               Return <a>this</a>'s <a data-for=
               "PerformanceResourceTiming">response body info</a>'s [=response body
-              info/encoded body size=] plus 300.
+              info/encoded size=] plus 300.
             </p>
             <p class='note'>
               The constant number added to `transferSize` replaces exposing the

--- a/index.html
+++ b/index.html
@@ -405,6 +405,11 @@
           info</dfn></a>.
         </p>
         <p>
+          A <a>PerformanceResourceTiming</a> has an associated [=fetch resource
+          info=] <a data-dfn-for="PerformanceResourceTiming"><dfn>resource
+          info</dfn></a>.
+        </p>
+        <p>
           The <a>PerformanceResourceTiming</a> interface participates in the
           <a data-cite=
           "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
@@ -653,13 +658,13 @@
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>encodedBodySize</dfn> getter steps are to return
-          <a>this</a>'s <a data-for="PerformanceResourceTiming">timing
-          info</a>'s [=fetch timing info/encoded body size=].
+          <a>this</a>'s <a data-for="PerformanceResourceTiming">resource
+          info</a>'s [=fetch resource info/encoded body size=].
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>decodedBodySize</dfn> getter steps are to return
-          <a>this</a>'s <a data-for="PerformanceResourceTiming">timing
-          info</a>'s [=fetch timing info/decoded body size=].
+          <a>this</a>'s <a data-for="PerformanceResourceTiming">resource
+          info</a>'s [=fetch resource info/decoded body size=].
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>transferSize</dfn> getter steps are to perform the following
@@ -681,7 +686,7 @@
           <li>
             <p>
               Return <a>this</a>'s <a data-for=
-              "PerformanceResourceTiming">timing info</a>'s [=fetch timing
+              "PerformanceResourceTiming">resource info</a>'s [=fetch resource
               info/encoded body size=] plus 300.
             </p>
             <p class='note'>
@@ -1056,8 +1061,8 @@
         <p>
           To <dfn data-export="">mark resource timing</dfn> given a [=/fetch
           timing info=] |timingInfo|, a DOMString |requestedURL|, a DOMString
-          |initiatorType| a <a>global object</a> |global|, and a string
-          |cacheMode|, perform the following steps:
+          |initiatorType| a <a>global object</a> |global|, a string
+          |cacheMode|, and a [=/fetch resource info=] |resourceInfo|, perform the following steps:
         </p>
         <ol>
           <li>Create a <a>PerformanceResourceTiming</a> object |entry| in
@@ -1065,7 +1070,7 @@
           </li>
           <li>
             <a>Setup the resource timing entry</a> for |entry|, given
-            |initiatorType|, |requestedURL|, |timingInfo|, and |cacheMode|.
+            |initiatorType|, |requestedURL|, |timingInfo|, |cacheMode|, and |resourceInfo|.
           </li>
           <li>
             <a data-cite=
@@ -1082,8 +1087,8 @@
           To <dfn data-export="">setup the resource timing entry</dfn> for
           <a>PerformanceResourceTiming</a> |entry| given DOMString
           |initiatorType|, DOMString |requestedURL|, [=/fetch timing info=]
-          |timingInfo|, and a DOMString |cacheMode|, perform the following
-          steps:
+          |timingInfo|, a DOMString |cacheMode|, and a [=fetch resource info=] |resourceInfo|,
+          perform the following steps:
         </p>
         <ol>
           <li>Assert that |cacheMode| is the empty string or
@@ -1097,6 +1102,8 @@
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">timing
           info</a> to |timingInfo|.
+          <li>Set |entry|'s <a data-for="PerformanceResourceTiming">resource
+          info</a> to |resourceInfo|.
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">cache
           mode</a> to |cacheMode|.

--- a/index.html
+++ b/index.html
@@ -659,12 +659,12 @@
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>encodedBodySize</dfn> getter steps are to return
           <a>this</a>'s <a data-for="PerformanceResourceTiming">resource
-          info</a>'s [=fetch resource info/encoded body size=].
+          info</a>'s [=response body info/encoded body size=].
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>decodedBodySize</dfn> getter steps are to return
           <a>this</a>'s <a data-for="PerformanceResourceTiming">resource
-          info</a>'s [=fetch resource info/decoded body size=].
+          info</a>'s [=response body info/decoded body size=].
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>transferSize</dfn> getter steps are to perform the following
@@ -686,7 +686,7 @@
           <li>
             <p>
               Return <a>this</a>'s <a data-for=
-              "PerformanceResourceTiming">resource info</a>'s [=fetch resource
+              "PerformanceResourceTiming">response body info</a>'s [=fetch resource
               info/encoded body size=] plus 300.
             </p>
             <p class='note'>
@@ -1062,7 +1062,7 @@
           To <dfn data-export="">mark resource timing</dfn> given a [=/fetch
           timing info=] |timingInfo|, a DOMString |requestedURL|, a DOMString
           |initiatorType| a <a>global object</a> |global|, a string
-          |cacheMode|, and a [=/fetch resource info=] |resourceInfo|, perform the following steps:
+          |cacheMode|, and a [=/response body info=] |bodyInfo|, perform the following steps:
         </p>
         <ol>
           <li>Create a <a>PerformanceResourceTiming</a> object |entry| in
@@ -1070,7 +1070,7 @@
           </li>
           <li>
             <a>Setup the resource timing entry</a> for |entry|, given
-            |initiatorType|, |requestedURL|, |timingInfo|, |cacheMode|, and |resourceInfo|.
+            |initiatorType|, |requestedURL|, |timingInfo|, |cacheMode|, and |bodyInfo|.
           </li>
           <li>
             <a data-cite=
@@ -1087,7 +1087,7 @@
           To <dfn data-export="">setup the resource timing entry</dfn> for
           <a>PerformanceResourceTiming</a> |entry| given DOMString
           |initiatorType|, DOMString |requestedURL|, [=/fetch timing info=]
-          |timingInfo|, a DOMString |cacheMode|, and a [=fetch resource info=] |resourceInfo|,
+          |timingInfo|, a DOMString |cacheMode|, and a [=response body info=] |bodyInfo|,
           perform the following steps:
         </p>
         <ol>
@@ -1102,8 +1102,8 @@
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">timing
           info</a> to |timingInfo|.
-          <li>Set |entry|'s <a data-for="PerformanceResourceTiming">resource
-          info</a> to |resourceInfo|.
+          <li>Set |entry|'s <a data-for="PerformanceResourceTiming">reponse body info</a>
+          to |bodyInfo|.
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">cache
           mode</a> to |cacheMode|.


### PR DESCRIPTION
As part of https://github.com/whatwg/fetch/pull/1413

Those numbers are per-response and not per-fetch, so they need to be
treated separately.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/321.html" title="Last updated on Jun 17, 2022, 2:46 PM UTC (9cf8453)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/321/148c98c...9cf8453.html" title="Last updated on Jun 17, 2022, 2:46 PM UTC (9cf8453)">Diff</a>