### PR TITLE
Clarify "downloadable"

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,12 +237,12 @@
         </h3>
         <p data-fn-for="html">
           The <a>PerformanceResourceTiming</a> interface facilitates timing
-          measurement of downloadable resources. For example, this interface is
-          available for {{XMLHttpRequest}} objects [[XHR]], HTML elements
+          measurement of [=fetch|fetched=] [=http(s) scheme|http(s)=] resources. For example,
+          this interface is available for {{XMLHttpRequest}} objects [[XHR]], HTML elements
           [[HTML]] such as [^iframe^], [^img^], [^script^], [^object^],
           [^embed^] and [^link^] with the link type of [^link/rel/stylesheet^],
-          and SVG elements [[SVG11]] such as <a data-cite=
-          "SVG11/struct.html#SVGElement">svg</a>.
+          SVG elements [[SVG11]] such as <a data-cite=
+          "SVG11/struct.html#SVGElement">svg</a>, and {{EventSource}}.
         </p>
       </section>
       <section>


### PR DESCRIPTION
Make it clear that resource timing reflects fetches of HTTP(s) resources,
which is a more accurate term than "downloadable".

Closes #100


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/324.html" title="Last updated on Apr 11, 2022, 12:43 PM UTC (c37883c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/324/66b113a...c37883c.html" title="Last updated on Apr 11, 2022, 12:43 PM UTC (c37883c)">Diff</a>