### PR TITLE
Add Render Blocking Status to PerformanceResourceTiming

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
               readonly attribute unsigned long long  transferSize;
               readonly attribute unsigned long long  encodedBodySize;
               readonly attribute unsigned long long  decodedBodySize;
-              readonly attribute DOMString renderBlockingStatus;
+              readonly attribute RenderBlockingStatusType renderBlockingStatus;
               [Default] object toJSON();
           };
         </pre>
@@ -409,6 +409,11 @@
           A <a>PerformanceResourceTiming</a> has an associated [=response body
           info=] <a data-dfn-for="PerformanceResourceTiming"><dfn>resource
           info</dfn></a>.
+        </p>
+        <p>
+          A <a>PerformanceResourceTiming</a> has an associated
+          {{RenderBlockingStatusType}} <a data-dfn-for=
+          "PerformanceResourceTiming"><dfn>render blocking status</dfn></a>.
         </p>
         <p>
           The <a>PerformanceResourceTiming</a> interface participates in the
@@ -700,10 +705,9 @@
           </li>
         </ol>
         <p data-dfn-for="PerformanceResourceTiming">
-          The <dfn>renderBlockingStatus</dfn> getter steps are to return
-          <code>"blocking"</code> if <a>this</a>'s <a data-for=
-          "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
-          render-blocking=] is true, else <code>"non-blocking"</code>
+          The <dfn>renderBlockingStatus</dfn> getter steps are to return the
+          <a data-for="PerformanceResourceTiming">render blocking status</a>
+          for <a>this</a>.
         </p>
         <p class='note'>
           A user agent implementing <a>PerformanceResourceTiming</a> would need
@@ -711,6 +715,38 @@
           {{PerformanceObserver/supportedEntryTypes}}. This allows developers
           to detect support for Resource Timing.
         </p>
+        <section id="sec-render-blocking-status-types">
+          <h4>
+            <dfn>RenderBlockingStatusType</dfn> enum
+          </h4>
+          <pre class='idl'>
+            enum RenderBlockingStatusType {
+                "blocking",
+                "non-blocking"
+            };
+          </pre>
+          <p>
+            The values are defined as follows:
+          </p>
+          <dl data-dfn-for='RenderBlockingStatusType'>
+            <dt>
+              <dfn>blocking</dfn>
+            </dt>
+            <dd>
+              Render blocking status where <a>this</a>'s <a data-for=
+              "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
+              render-blocking=] is true.
+            </dd>
+            <dt>
+              <dfn>non-blocking</dfn>
+            </dt>
+            <dd>
+              Render blocking status where <a>this</a>'s <a data-for=
+              "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
+              render-blocking=] is false.
+            </dd>
+          </dl>
+        </section>
       </section>
       <section id="sec-extensions-performance-interface" data-dfn-for=
       "Performance">

--- a/index.html
+++ b/index.html
@@ -708,9 +708,8 @@
           The <dfn>renderBlockingStatus</dfn> getter steps are to return
           <a data-link-for="RenderBlockingStatusType">blocking</a>
           if <a>this</a>'s <a data-for="PerformanceResourceTiming">timing
-          info</a>'s [=fetch timing info/render-blocking=] is true
-          else <a data-link-for="RenderBlockingStatusType">non-blocking</a>
-          and the <a>relevant global object</a> for <a>this</a>.
+          info</a>'s [=fetch timing info/render-blocking=] is true; otherwise
+          <a data-link-for="RenderBlockingStatusType">non-blocking</a>.
         </p>
         <p class='note'>
           A user agent implementing <a>PerformanceResourceTiming</a> would need

--- a/index.html
+++ b/index.html
@@ -380,6 +380,7 @@
               readonly attribute unsigned long long  transferSize;
               readonly attribute unsigned long long  encodedBodySize;
               readonly attribute unsigned long long  decodedBodySize;
+              readonly attribute DOMString renderBlockingStatus;
               [Default] object toJSON();
           };
         </pre>
@@ -698,6 +699,12 @@
             </p>
           </li>
         </ol>
+        <p data-dfn-for="PerformanceResourceTiming">
+          The <dfn>renderBlockingStatus</dfn> getter steps are to return
+          <code>"blocking"</code> if <a>this</a>'s <a data-for=
+          "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
+          render-blocking=] is true, else <code>"non-blocking"</code>
+        </p>
         <p class='note'>
           A user agent implementing <a>PerformanceResourceTiming</a> would need
           to include <code>"resource"</code> in

--- a/index.html
+++ b/index.html
@@ -413,7 +413,7 @@
         <p>
           A <a>PerformanceResourceTiming</a> has an associated
           {{RenderBlockingStatusType}} <a data-dfn-for=
-          "PerformanceResourceTiming"><dfn>render blocking status</dfn></a>.
+          "PerformanceResourceTiming"><dfn>render-blocking status</dfn></a>.
         </p>
         <p>
           The <a>PerformanceResourceTiming</a> interface participates in the
@@ -706,7 +706,7 @@
         </ol>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>renderBlockingStatus</dfn> getter steps are to return the
-          <a data-for="PerformanceResourceTiming">render blocking status</a>
+          <a data-for="PerformanceResourceTiming">render-blocking status</a>
           for <a>this</a>.
         </p>
         <p class='note'>
@@ -733,7 +733,7 @@
               <dfn>blocking</dfn>
             </dt>
             <dd>
-              Render blocking status where <a>this</a>'s <a data-for=
+              Render-blocking status where <a>this</a>'s <a data-for=
               "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
               render-blocking=] is true.
             </dd>
@@ -741,7 +741,7 @@
               <dfn>non-blocking</dfn>
             </dt>
             <dd>
-              Render blocking status where <a>this</a>'s <a data-for=
+              Render-blocking status where <a>this</a>'s <a data-for=
               "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
               render-blocking=] is false.
             </dd>

--- a/index.html
+++ b/index.html
@@ -705,9 +705,12 @@
           </li>
         </ol>
         <p data-dfn-for="PerformanceResourceTiming">
-          The <dfn>renderBlockingStatus</dfn> getter steps are to return the
-          <a data-for="PerformanceResourceTiming">render-blocking status</a>
-          for <a>this</a>.
+          The <dfn>renderBlockingStatus</dfn> getter steps are to return
+          <a data-link-for="RenderBlockingStatusType">blocking</a>
+          if <a>this</a>'s <a data-for="PerformanceResourceTiming">timing
+          info</a>'s [=fetch timing info/render-blocking=] is true
+          else <a data-link-for="RenderBlockingStatusType">non-blocking</a>
+          and the <a>relevant global object</a> for <a>this</a>.
         </p>
         <p class='note'>
           A user agent implementing <a>PerformanceResourceTiming</a> would need
@@ -733,17 +736,13 @@
               <dfn>blocking</dfn>
             </dt>
             <dd>
-              Render-blocking status where <a>this</a>'s <a data-for=
-              "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
-              render-blocking=] is true.
+              The resource can potentially block rendering.
             </dd>
             <dt>
               <dfn>non-blocking</dfn>
             </dt>
             <dd>
-              Render-blocking status where <a>this</a>'s <a data-for=
-              "PerformanceResourceTiming">timing info</a>'s [=fetch timing info/
-              render-blocking=] is false.
+              The resource will not block rendering.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Introducing a render blocking status field. (https://github.com/w3c/resource-timing/issues/262)
Fetch changes : https://github.com/whatwg/fetch/pull/1449
~~HTML changes: https://github.com/whatwg/html/pull/7979~~

Explainer : https://github.com/abinpaul1/resource-timing/blob/render-blocking-status-explainer/Explainer/Render_Blocking_Status.md


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/abinpaul1/resource-timing/pull/327.html" title="Last updated on Aug 10, 2022, 6:11 PM UTC (41acb22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/327/e71c2ab...abinpaul1:41acb22.html" title="Last updated on Aug 10, 2022, 6:11 PM UTC (41acb22)">Diff</a>