### PR TITLE
Fix the assertion in setup the resource timing entry.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1093,8 +1093,8 @@
           |bodyInfo|, perform the following steps:
         </p>
         <ol>
-          <li>Assert that |cacheMode| is the empty string or
-          "<code>local</code>".
+          <li>Assert that |cacheMode| is the empty string, "<code>local</code>",
+          or "<code>validated</code>".
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">initiator
           type</a> to |initiatorType|.


### PR DESCRIPTION
#272 (a4628756a5337343ae1d9deef915198c2b6a3121) added a third option, `"validated"`, but the assertion was not updated. Consequently anything served from cache after revalidation currently fails this assertion, but should not.