### PR TITLE
Add response status code to PerfomanceResourceTiming

### DIFF
--- a/index.html
+++ b/index.html
@@ -718,13 +718,13 @@
         </ol>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>responseStatus</dfn> getter steps are to return
-          <a data-for="PerformanceResourceTiming">response status </a>for
-          <a>this</a>.
+          <a>this</a>'s <a data-for="PerformanceResourceTiming">response status</a>.
         </p>
         <p class='note'>
-          `responseStatus` is determined in [=Fetch=]. For a no-cors request
-          it would be 0 because the response would be an <a data-cite=
-          "FETCH#concept filtered response opaque">opaque filtered response</a>.
+          `responseStatus` is determined in [=Fetch=]. For a <a data-cite=
+          "FETCH#dom-requestmode-no-cors">no-cors</a> request it would be 0
+          because the response would be an <a data-cite=
+          "FETCH#concept-filtered-response-opaque">opaque filtered response</a>.
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>renderBlockingStatus</dfn> getter steps are to return

--- a/index.html
+++ b/index.html
@@ -380,6 +380,7 @@
               readonly attribute unsigned long long  transferSize;
               readonly attribute unsigned long long  encodedBodySize;
               readonly attribute unsigned long long  decodedBodySize;
+              readonly attribute unsigned short responseStatus;
               [Default] object toJSON();
           };
         </pre>
@@ -408,6 +409,11 @@
           A <a>PerformanceResourceTiming</a> has an associated [=response body
           info=] <a data-dfn-for="PerformanceResourceTiming"><dfn>resource
           info</dfn></a>.
+        </p>
+        <p>
+          A <a>PerformanceResourceTiming</a> has an associated
+          <a data-cite="FETCH#concept-status">status</a> <a data-dfn-for=
+          "PerformanceResourceTiming"><dfn>response status</dfn></a>.
         </p>
         <p>
           The <a>PerformanceResourceTiming</a> interface participates in the
@@ -698,6 +704,11 @@
             </p>
           </li>
         </ol>
+        <p data-dfn-for="PerformanceResourceTiming">
+          The <dfn>responseStatus</dfn> getter steps are to return
+          <a data-for="PerformanceResourceTiming">response status </a>for
+          <a>this</a>.
+        </p>
         <p class='note'>
           A user agent implementing <a>PerformanceResourceTiming</a> would need
           to include <code>"resource"</code> in
@@ -942,7 +953,10 @@
           {{PerformanceResourceTiming/encodedBodySize}}, and
           {{PerformanceResourceTiming/decodedBodySize}}. Further, the
           {{PerformanceResourceTiming/nextHopProtocol}} attribute will be set
-          to the empty string.
+          to the empty string. If the <a data-cite=
+          "FETCH#concept-cors-check"> CORS check</a> fails the following
+          attributes will be set to zero:
+          {{PerformanceResourceTiming/responseStatus}}.
         </p>
         <p>
           Server-side applications may return the <a>Timing-Allow-Origin</a>
@@ -1062,8 +1076,9 @@
           To <dfn data-export="">mark resource timing</dfn> given a [=/fetch
           timing info=] |timingInfo|, a DOMString |requestedURL|, a DOMString
           |initiatorType| a <a>global object</a> |global|, a string
-          |cacheMode|, and a [=/response body info=] |bodyInfo|, perform the
-          following steps:
+          |cacheMode|, a [=/response body info=] |bodyInfo|, and a
+          <a data-cite="FETCH#concept-status">status</a> |responseStatus|,
+          perform the following steps:
         </p>
         <ol>
           <li>Create a <a>PerformanceResourceTiming</a> object |entry| in
@@ -1071,8 +1086,8 @@
           </li>
           <li>
             <a>Setup the resource timing entry</a> for |entry|, given
-            |initiatorType|, |requestedURL|, |timingInfo|, |cacheMode|, and
-            |bodyInfo|.
+            |initiatorType|, |requestedURL|, |timingInfo|, |cacheMode|,
+            |bodyInfo| and |responseStatus|.
           </li>
           <li>
             <a data-cite=
@@ -1089,8 +1104,9 @@
           To <dfn data-export="">setup the resource timing entry</dfn> for
           <a>PerformanceResourceTiming</a> |entry| given DOMString
           |initiatorType|, DOMString |requestedURL|, [=/fetch timing info=]
-          |timingInfo|, a DOMString |cacheMode|, and a [=response body info=]
-          |bodyInfo|, perform the following steps:
+          |timingInfo|, a DOMString |cacheMode|, a [=response body info=]
+          |bodyInfo|, and a <a data-cite="FETCH#concept-status">status</a>
+          |responseStatus|, perform the following steps:
         </p>
         <ol>
           <li>Assert that |cacheMode| is the empty string,
@@ -1110,6 +1126,9 @@
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">cache
           mode</a> to |cacheMode|.
+          </li>
+          <li>Set |entry|'s <a data-for="PerformanceResourceTiming">response
+          status</a> to |responseStatus|.
           </li>
         </ol>
         <p>

--- a/index.html
+++ b/index.html
@@ -721,9 +721,9 @@
           <a>this</a>'s <a data-for="PerformanceResourceTiming">response status</a>.
         </p>
         <p class='note'>
-          `responseStatus` is determined in [=Fetch=]. For a <a data-cite=
-          "FETCH#dom-requestmode-no-cors">no-cors</a> request it would be 0
-          because the response would be an <a data-cite=
+          `responseStatus` is determined in [=Fetch=]. For a cross-origin
+          <a data-cite="FETCH#dom-requestmode-no-cors">no-cors</a> request it
+          would be 0 because the response would be an <a data-cite=
           "FETCH#concept-filtered-response-opaque">opaque filtered response</a>.
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
@@ -1005,10 +1005,7 @@
           {{PerformanceResourceTiming/encodedBodySize}}, and
           {{PerformanceResourceTiming/decodedBodySize}}. Further, the
           {{PerformanceResourceTiming/nextHopProtocol}} attribute will be set
-          to the empty string. If the <a data-cite=
-          "FETCH#concept-cors-check"> CORS check</a> fails the following
-          attributes will be set to zero:
-          {{PerformanceResourceTiming/responseStatus}}.
+          to the empty string.
         </p>
         <p>
           Server-side applications may return the <a>Timing-Allow-Origin</a>

--- a/index.html
+++ b/index.html
@@ -710,6 +710,11 @@
           <a>this</a>.
         </p>
         <p class='note'>
+          `responseStatus` is determined in [=Fetch=]. For a no-cors request
+          it would be 0 because the response would be an <a data-cite=
+          "FETCH#concept filtered response opaque">opaque filtered response</a>.
+        </p>
+        <p class='note'>
           A user agent implementing <a>PerformanceResourceTiming</a> would need
           to include <code>"resource"</code> in
           {{PerformanceObserver/supportedEntryTypes}}. This allows developers


### PR DESCRIPTION
Introducing HTTP response status code. (https://github.com/w3c/resource-timing/issues/90)
Fetch changes : https://github.com/whatwg/fetch/pull/1468

Explainer : https://github.com/abinpaul1/resource-timing/blob/explainer-resource-response-status/Explainers/Response_Status_Code.md


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/abinpaul1/resource-timing/pull/335.html" title="Last updated on Oct 24, 2022, 4:46 PM UTC (053cf41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/335/958ccdd...abinpaul1:053cf41.html" title="Last updated on Oct 24, 2022, 4:46 PM UTC (053cf41)">Diff</a>