### PR TITLE
chore: Fix missing curly brace

### DIFF
--- a/index.html
+++ b/index.html
@@ -941,7 +941,7 @@
           {{PerformanceResourceTiming/transferSize}},
           {{PerformanceResourceTiming/encodedBodySize}}, and
           {{PerformanceResourceTiming/decodedBodySize}}. Further, the
-          {{PerformanceResourceTiming/nextHopProtocol} attribute will be set to
+          {{PerformanceResourceTiming/nextHopProtocol}} attribute will be set to
           the empty string.
         </p>
         <p>


### PR DESCRIPTION
Missing a closing curly.

https://w3c.github.io/resource-timing/#sec-cross-origin-resources

![image](https://user-images.githubusercontent.com/1004649/179536716-67770b70-3c21-49c3-9282-e904c916d8af.png)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/337.html" title="Last updated on Jul 18, 2022, 2:42 PM UTC (817406e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/337/147d0fc...817406e.html" title="Last updated on Jul 18, 2022, 2:42 PM UTC (817406e)">Diff</a>