### PR TITLE
Add interim response times

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,7 +367,10 @@
               readonly attribute DOMHighResTimeStamp connectEnd;
               readonly attribute DOMHighResTimeStamp secureConnectionStart;
               readonly attribute DOMHighResTimeStamp requestStart;
+              readonly attribute DOMHighResTimeStamp firstInterimResponseStart;
               readonly attribute DOMHighResTimeStamp responseStart;
+              readonly attribute DOMHighResTimeStamp responseHeadersEnd;
+              readonly attribute DOMHighResTimeStamp responseBodyStart;
               readonly attribute DOMHighResTimeStamp responseEnd;
               readonly attribute unsigned long long  transferSize;
               readonly attribute unsigned long long  encodedBodySize;
@@ -682,10 +685,31 @@
           object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
+          The <dfn>firstInterimResponseStart</dfn> getter steps are to <a>convert fetch
+          timestamp</a> for <a>this</a>'s <a data-for=
+          "PerformanceResourceTiming">timing info</a>'s [=fetch timing
+          info/first interim network-response start time=] and the <a>relevant global
+          object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
+        </p>
+        <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>responseStart</dfn> getter steps are to <a>convert fetch
           timestamp</a> for <a>this</a>'s <a data-for=
           "PerformanceResourceTiming">timing info</a>'s [=fetch timing
           info/final network-response start time=] and the <a>relevant global
+          object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
+        </p>
+        <p data-dfn-for="PerformanceResourceTiming">
+          The <dfn>responseHeadersEnd</dfn> getter steps are to <a>convert fetch
+          timestamp</a> for <a>this</a>'s <a data-for=
+          "PerformanceResourceTiming">timing info</a>'s [=fetch timing
+          info/final network-response headers end time=] and the <a>relevant global
+          object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
+        </p>
+        <p data-dfn-for="PerformanceResourceTiming">
+          The <dfn>responseBodyStart</dfn> getter steps are to <a>convert fetch
+          timestamp</a> for <a>this</a>'s <a data-for=
+          "PerformanceResourceTiming">timing info</a>'s [=fetch timing
+          info/final network-response body start time=] and the <a>relevant global
           object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
@@ -1022,7 +1046,10 @@
           {{PerformanceResourceTiming/connectStart}},
           {{PerformanceResourceTiming/connectEnd}},
           {{PerformanceResourceTiming/requestStart}},
+          {{PerformanceResourceTiming/firstInterimResponseStart}},
           {{PerformanceResourceTiming/responseStart}},
+          {{PerformanceResourceTiming/responseHeadersEnd}},
+          {{PerformanceResourceTiming/responseBodyStart}},
           {{PerformanceResourceTiming/secureConnectionStart}},
           {{PerformanceResourceTiming/transferSize}},
           {{PerformanceResourceTiming/encodedBodySize}}, and

--- a/index.html
+++ b/index.html
@@ -369,8 +369,6 @@
               readonly attribute DOMHighResTimeStamp requestStart;
               readonly attribute DOMHighResTimeStamp firstInterimResponseStart;
               readonly attribute DOMHighResTimeStamp responseStart;
-              readonly attribute DOMHighResTimeStamp responseHeadersEnd;
-              readonly attribute DOMHighResTimeStamp responseBodyStart;
               readonly attribute DOMHighResTimeStamp responseEnd;
               readonly attribute unsigned long long  transferSize;
               readonly attribute unsigned long long  encodedBodySize;
@@ -696,20 +694,6 @@
           timestamp</a> for <a>this</a>'s <a data-for=
           "PerformanceResourceTiming">timing info</a>'s [=fetch timing
           info/final network-response start time=] and the <a>relevant global
-          object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
-        </p>
-        <p data-dfn-for="PerformanceResourceTiming">
-          The <dfn>responseHeadersEnd</dfn> getter steps are to <a>convert fetch
-          timestamp</a> for <a>this</a>'s <a data-for=
-          "PerformanceResourceTiming">timing info</a>'s [=fetch timing
-          info/final network-response headers end time=] and the <a>relevant global
-          object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
-        </p>
-        <p data-dfn-for="PerformanceResourceTiming">
-          The <dfn>responseBodyStart</dfn> getter steps are to <a>convert fetch
-          timestamp</a> for <a>this</a>'s <a data-for=
-          "PerformanceResourceTiming">timing info</a>'s [=fetch timing
-          info/final network-response body start time=] and the <a>relevant global
           object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
@@ -1048,8 +1032,6 @@
           {{PerformanceResourceTiming/requestStart}},
           {{PerformanceResourceTiming/firstInterimResponseStart}},
           {{PerformanceResourceTiming/responseStart}},
-          {{PerformanceResourceTiming/responseHeadersEnd}},
-          {{PerformanceResourceTiming/responseBodyStart}},
           {{PerformanceResourceTiming/secureConnectionStart}},
           {{PerformanceResourceTiming/transferSize}},
           {{PerformanceResourceTiming/encodedBodySize}}, and


### PR DESCRIPTION
Add `firstInterimResponseStart`: the first response with an informational (1XX) status.

Bug: #345
Depends on whatwg/fetch#1483

For now not adding headers-end and body-start as they're not planned to be implemented.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/366.html" title="Last updated on May 8, 2023, 9:41 AM UTC (b82c99e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/366/95c8d0b...b82c99e.html" title="Last updated on May 8, 2023, 9:41 AM UTC (b82c99e)">Diff</a>