### PR TITLE
Allow user agents to enforce cross-origin restrictions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,7 +1012,7 @@
           </h4>
           <p>
             The <dfn>Timing-Allow-Origin</dfn> HTTP response header field can
-            be used to communicate a policy indicating origin(s) that are
+            be used to communicate a policy indicating origin(s) that may be
             allowed to see values of attributes that would have been zero due
             to the cross-origin restrictions. The header's value is represented
             by the following ABNF [[RFC5234]] (using <a data-cite=
@@ -1026,6 +1026,11 @@
             <a>Timing-Allow-Origin</a> header fields by appending each
             subsequent field value to the combined field value in order,
             separated by a comma.
+          </p>
+          <p>
+            The user agent MAY still enforce cross-origin restrictions and set
+            transferSize, encodedBodySize, and decodedBodySize attributes to
+            zero, even with Timing-Allow-Origin HTTP response header fields.
           </p>
           <p>
             The <a>Timing-Allow-Origin</a> headers are processed in
@@ -1233,8 +1238,8 @@
           Thanks to Anne Van Kesteren, Annie Sullivan, Arvind Jain, Boris
           Zbarsky, Darin Fisher, Jason Weber, Jonas Sicking, James Simonsen,
           Karen Anderson, Kyle Scholz, Nic Jansma, Philippe Le Hegaret,
-          Sigbjørn Vik, Steve Souders, Todd Reifsteck, Tony Gentilcore and
-          William Chan for their contributions to this work.
+          Sigbjørn Vik, Steve Souders, Todd Reifsteck, Tony Gentilcore,
+          William Chan, and Alex Christensen for their contributions to this work.
         </p>
       </section>
     </section>


### PR DESCRIPTION
even with the presence of TAO header fields.  This resolves https://github.com/w3c/resource-timing/issues/342


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/achristensen07/resource-timing/pull/369.html" title="Last updated on Jan 26, 2023, 8:08 PM UTC (01dafaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/369/85e74ce...achristensen07:01dafaf.html" title="Last updated on Jan 26, 2023, 8:08 PM UTC (01dafaf)">Diff</a>