### PR TITLE
Add http method to ResourceTiming interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,7 @@
               readonly attribute DOMString initiatorType;
               readonly attribute DOMString deliveryType;
               readonly attribute ByteString nextHopProtocol;
+              readonly attribute ByteString httpMethod;
               readonly attribute DOMHighResTimeStamp workerStart;
               readonly attribute DOMHighResTimeStamp redirectStart;
               readonly attribute DOMHighResTimeStamp redirectEnd;
@@ -397,6 +398,10 @@
           <a data-dfn-for="PerformanceResourceTiming"><dfn>cache mode</dfn></a>
           (the empty string, "<code>local</code>", or
           "<code>validated</code>").
+        </p>
+        <p>
+          A <a>PerformanceResourceTiming</a> has an associated ByteString
+          <a data-dfn-for="PerformanceResourceTiming"><dfn>http method</dfn></a>
         </p>
         <p>
           A <a>PerformanceResourceTiming</a> has an associated [=fetch timing
@@ -737,6 +742,11 @@
             </p>
           </li>
         </ol>
+        <p data-dfn-for="PerformanceResourceTiming">
+          The <dfn>httpMethod</dfn> getter steps are to return
+          <a>this</a>'s <a data-cite="FETCH#concept-method-normalize">normalized</a>
+           <a data-for="PerformanceResourceTiming">http method</a>.
+        </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>responseStatus</dfn> getter steps are to return
           <a>this</a>'s <a data-for="PerformanceResourceTiming">response


### PR DESCRIPTION
Add HTTP Method to ResourceTiming (#373)
Fetch changes: whatwg/fetch#1632

Explainer: https://github.com/sohomdatta1/rt-explainer


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sohomdatta1/resource-timing/pull/375.html" title="Last updated on Apr 17, 2023, 12:43 PM UTC (debfeca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/375/95c8d0b...sohomdatta1:debfeca.html" title="Last updated on Apr 17, 2023, 12:43 PM UTC (debfeca)">Diff</a>