### PR TITLE
WebIDL fix: initialize PerformanceEntry instead of shadowing

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,60 +420,6 @@
           {{RenderBlockingStatusType}} <a data-dfn-for=
           "PerformanceResourceTiming"><dfn>render-blocking status</dfn></a>.
         </p>
-        <p>
-          The <a>PerformanceResourceTiming</a> interface participates in the
-          <a data-cite=
-          "PERFORMANCE-TIMELINE-2#performance-timeline">Performance
-          Timeline</a> and extends the following attributes of the
-          <code><dfn data-cite=
-          "PERFORMANCE-TIMELINE-2#the-performanceentry-interface">PerformanceEntry</dfn></code>
-          interface:
-        </p>
-        <dl data-link-for="PerformanceResourceTiming">
-          <dt>
-            <dfn>name</dfn>
-          </dt>
-          <dd>
-            The <a>name</a> getter steps are to return <a>this</a>'s
-            <a data-for="PerformanceResourceTiming">requested URL</a>.
-          </dd>
-          <dt>
-            <dfn>entryType</dfn>
-          </dt>
-          <dd>
-            The <a>entryType</a> getter steps are to return the DOMString
-            "<code>resource</code>".
-          </dd>
-          <dt>
-            <dfn>startTime</dfn>
-          </dt>
-          <dd>
-            <p data-dfn-for="PerformanceResourceTiming">
-              The <a>startTime</a> getter steps are to <a>convert fetch
-              timestamp</a> for <a>this</a>'s <a data-for=
-              "PerformanceResourceTiming">timing info</a>'s [=fetch timing
-              info/start time=] and <a>this</a>'s <a>relevant global
-              object</a>.
-            </p>
-            <p class='note'>
-              `startTime` is measured right at the start of the [=fetch=],
-              before any redirects. See <a data-cite=
-              "FETCH#fetching">fetching</a>.
-            </p>
-          </dd>
-          <dt>
-            <dfn>duration</dfn>
-          </dt>
-          <dd>
-            <p data-dfn-for="PerformanceResourceTiming">
-              The <a>duration</a> getter steps are to return <a>this</a>'s
-              <a data-for="PerformanceResourceTiming">timing info</a>'s [=fetch
-              timing info/end time=] minus <a>this</a>'s <a data-for=
-              "PerformanceResourceTiming">timing info</a>'s [=fetch timing
-              info/start time=].
-            </p>
-          </dd>
-        </dl>
         <p data-dfn-for="PerformanceResourceTiming">
           When <dfn>toJSON</dfn> is called, run [[WEBIDL]]'s <a data-cite=
           "WEBIDL#default-tojson-operation">default toJSON operation</a>.
@@ -1185,6 +1131,7 @@
           <li>Create a <a>PerformanceResourceTiming</a> object |entry| in
           |global|'s [=global object/realm=].
           </li>
+
           <li>
             <a>Setup the resource timing entry</a> for |entry|, given
             |initiatorType|, |requestedURL|, |timingInfo|, |cacheMode|,
@@ -1213,6 +1160,13 @@
         <ol>
           <li>Assert that |cacheMode| is the empty string,
           "<code>local</code>", or "<code>validated</code>".
+          </li>
+
+          <li>[=initialize a PerformanceEntry|Initialize=] |entry| given
+            the result of <a data-lt="convert fetch timestamp">converting</a> |timingInfo|'s
+            [=fetch timing info/start time=], "<code>resource</code>",
+            |requestedURL|, and the result of <a data-lt="convert fetch timestamp">converting</a>
+            |timingInfo|'s [=fetch timing info/end time=].
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">initiator
           type</a> to |initiatorType|.

--- a/index.html
+++ b/index.html
@@ -845,15 +845,12 @@
           </li>
         </ol>
         <p>
-          To <dfn>add a PerformanceResourceTiming entry</dfn> into the
+          To <dfn>add a PerformanceResourceTiming entry</dfn> <i>new entry</i> into the
           <a data-cite=
           'PERFORMANCE-TIMELINE-2/#dfn-performance-entry-buffer'>performance
           entry buffer</a>, run the following steps:
         </p>
         <ol>
-          <li>Let <i>new entry</i> be the input <a>PerformanceEntry</a> to be
-          added.
-          </li>
           <li>If <a>can add resource timing entry</a> returns true and
           <a>resource timing buffer full event pending flag</a> is false, run
           the following substeps:

--- a/index.html
+++ b/index.html
@@ -1159,11 +1159,13 @@
           "<code>local</code>", or "<code>validated</code>".
           </li>
 
+          <li>Let |global| be |entry|'s [=relevant global object=].</li>
+
           <li>[=initialize a PerformanceEntry|Initialize=] |entry| given
             the result of <a data-lt="convert fetch timestamp">converting</a> |timingInfo|'s
-            [=fetch timing info/start time=], "<code>resource</code>",
+            [=fetch timing info/start time=] given |global|, "<code>resource</code>",
             |requestedURL|, and the result of <a data-lt="convert fetch timestamp">converting</a>
-            |timingInfo|'s [=fetch timing info/end time=].
+            |timingInfo|'s [=fetch timing info/end time=] given |global|.
           </li>
           <li>Set |entry|'s <a data-for="PerformanceResourceTiming">initiator
           type</a> to |initiatorType|.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/383.html" title="Last updated on Feb 8, 2024, 10:13 AM UTC (e2720dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/383/23da0c2...e2720dd.html" title="Last updated on Feb 8, 2024, 10:13 AM UTC (e2720dd)">Diff</a>