### PR TITLE
Fix broken reference to RFC7230

### DIFF
--- a/index.html
+++ b/index.html
@@ -1001,7 +1001,7 @@
             allowed to see values of attributes that would have been zero due
             to the cross-origin restrictions. The header's value is represented
             by the following ABNF [[RFC5234]] (using <a data-cite=
-            "RFC7230#section-7">List Extension</a>, [[RFC7230]]):
+            "RFC9110#rfc.section.5.6.1">List Extension</a>, [[RFC9110]]):
           </p><code class="abnf">Timing-Allow-Origin = 1#( <a data-cite=
           "FETCH#origin-header">origin-or-null</a> / <a data-cite=
           "FETCH#http-new-header-syntax">wildcard</a> )</code>


### PR DESCRIPTION
RFC7230 is replaced with RFC9110; update the reference to list ABNF syntax accordingly

Closes: #404


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/406.html" title="Last updated on Aug 30, 2024, 2:46 AM UTC (c558a4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/406/1cb5bd3...c558a4f.html" title="Last updated on Aug 30, 2024, 2:46 AM UTC (c558a4f)">Diff</a>