### PR TITLE
Add finalResponseHeadersStart which is always the 2xx/4xx/5xx response.

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,6 +366,7 @@
               readonly attribute DOMHighResTimeStamp connectEnd;
               readonly attribute DOMHighResTimeStamp secureConnectionStart;
               readonly attribute DOMHighResTimeStamp requestStart;
+              readonly attribute DOMHighResTimeStamp finalResponseHeadersStart;
               readonly attribute DOMHighResTimeStamp firstInterimResponseStart;
               readonly attribute DOMHighResTimeStamp responseStart;
               readonly attribute DOMHighResTimeStamp responseEnd;
@@ -636,11 +637,16 @@
           global object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
-          The <dfn>responseStart</dfn> getter steps are to <a>convert fetch
+          The <dfn>finalResponseHeadersStart</dfn> getter steps are to <a>convert fetch
           timestamp</a> for <a>this</a>'s <a data-for=
           "PerformanceResourceTiming">timing info</a>'s [=fetch timing
           info/final network-response start time=] and the <a>relevant global
           object</a> for <a>this</a>. See [=/HTTP fetch=] for more info.
+        </p>
+        <p data-dfn-for="PerformanceResourceTiming">
+          The <dfn>responseStart</dfn> getter steps are to return <a>this</a>'s
+          {{PerformanceResourceTiming/firstInterimResponseStart}} if it is not 0; Otherwise
+          <a>this</a>'s {{PerformanceResourceTiming/finalResponseHeadersStart}}.
         </p>
         <p data-dfn-for="PerformanceResourceTiming">
           The <dfn>responseEnd</dfn> getter steps are to <a>convert fetch
@@ -978,6 +984,7 @@
           {{PerformanceResourceTiming/connectEnd}},
           {{PerformanceResourceTiming/requestStart}},
           {{PerformanceResourceTiming/firstInterimResponseStart}},
+          {{PerformanceResourceTiming/finalResponseHeadersStart}},
           {{PerformanceResourceTiming/responseStart}},
           {{PerformanceResourceTiming/secureConnectionStart}},
           {{PerformanceResourceTiming/transferSize}},


### PR DESCRIPTION
responseStart now returns `firstInterimResponseStart` as before, but falls back to `finalResponseHeadersStart` if there is no interim response.

Closes #345