### PR TITLE
Fix up broken links in Fetch and HTML

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1127,7 +1127,7 @@ sufficiently (by calling
     Creating a resource timing entry
   </h2>
   <p>
-    To <dfn export>mark resource timing</dfn> given a [=/fetch
+    To <dfn export oldids="dfn-mark-resource-timing">mark resource timing</dfn> given a [=/fetch
     timing info=] |timingInfo|, a DOMString |requestedURL|, a DOMString
     |initiatorType| a <a>global object</a> |global|, a string
     |cacheMode|, a [=/response body info=] |bodyInfo|, a
@@ -1152,7 +1152,7 @@ sufficiently (by calling
     </li>
   </ol>
   <p>
-    To <dfn export>setup the resource timing entry</dfn> for
+    To <dfn export oldids="dfn-setup-the-resource-timing-entry">setup the resource timing entry</dfn> for
     {{PerformanceResourceTiming}} |entry| given DOMString
     |initiatorType|, DOMString |requestedURL|, [=/fetch timing info=]
     |timingInfo|, a DOMString |cacheMode|, a [=response body info=]


### PR DESCRIPTION
Fixes https://github.com/whatwg/fetch/issues/1916


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/pull/431.html" title="Last updated on Mar 23, 2026, 2:50 PM UTC (74de54b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/resource-timing/431/b5c3a6f...74de54b.html" title="Last updated on Mar 23, 2026, 2:50 PM UTC (74de54b)">Diff</a>